### PR TITLE
feature/web dashboard epic

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.17.0</Version>
+    <Version>1.18.0</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.14.0</Version>
+    <Version>1.15.0</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.15.0</Version>
+    <Version>1.15.1</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.16.0</Version>
+    <Version>1.17.0</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.15.1</Version>
+    <Version>1.16.0</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.13.1</Version>
+    <Version>1.13.2</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     <analysislevel>latest-Recommended</analysislevel>
     <analysismode>Recommended</analysismode>
 
-    <Version>1.13.2</Version>
+    <Version>1.14.0</Version>
 
     <RootNamespace>KuriousLabs.Kurio</RootNamespace>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.14.0-beta.2" />
     <PackageVersion Include="Polly" Version="8.6.5" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,8 +36,11 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
     <!-- Test Dependencies -->
+    <PackageVersion Include="bunit" Version="1.34.0" />
+    <PackageVersion Include="bunit.web" Version="1.34.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/KuriousLabs.Kurio.slnx
+++ b/KuriousLabs.Kurio.slnx
@@ -7,6 +7,7 @@
     <Project Path="src/Kurio.Contracts/Kurio.Contracts.csproj" />
     <Project Path="src/Kurio.Server/Kurio.Server.csproj" />
     <Project Path="src/Kurio.ServiceDefaults/Kurio.ServiceDefaults.csproj" />
+    <Project Path="src/Kurio.Web/Kurio.Web.csproj" />
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Kurio.Core.Tests/Kurio.Core.Tests.csproj" />
@@ -28,5 +29,6 @@
   </Folder>
   <Folder Name="/docs/prd/">
     <File Path="docs/prd/web-dashboard.md" />
+    <File Path="docs/prd/kurio-web-host.md" />
   </Folder>
 </Solution>

--- a/KuriousLabs.Kurio.slnx
+++ b/KuriousLabs.Kurio.slnx
@@ -25,20 +25,7 @@
   <Folder Name="/.github/">
     <File Path=".github/copilot-instructions.md" />
   </Folder>
-  <Folder Name="/docs/">
-    <File Path="docs/implementation-plan.md" />
-    <File Path="docs\implementation-summary-connection-loss-recovery-fix.md" />
-    <File Path="docs\implementation-summary-connection-resilience.md" />
-  </Folder>
-  <Folder Name="/docs/architecture/">
-    <File Path="docs/architecture/domain-model.md" />
-  </Folder>
   <Folder Name="/docs/prd/">
-    <File Path="docs/prd/core-engine-architecture.md" />
-    <File Path="docs/prd/configuration-and-storage.md" />
-    <File Path="docs/prd/tui-implementation.md" />
-    <File Path="docs/prd/web-service-architecture.md" />
-    <File Path="docs\prd\connection-resilience.md" />
     <File Path="docs/prd/web-dashboard.md" />
   </Folder>
 </Solution>

--- a/KuriousLabs.Kurio.slnx
+++ b/KuriousLabs.Kurio.slnx
@@ -10,6 +10,7 @@
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Kurio.Core.Tests/Kurio.Core.Tests.csproj" />
+    <Project Path="test/Kurio.Server.Tests/Kurio.Server.Tests.csproj" />
   </Folder>
 
   <Folder Name="/misc/">

--- a/KuriousLabs.Kurio.slnx
+++ b/KuriousLabs.Kurio.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/Kurio.Avalonia/Kurio.Avalonia.csproj" />
     <Project Path="src/Kurio.Cli/Kurio.Cli.csproj" />
     <Project Path="src/Kurio.Core/Kurio.Core.csproj" />
+    <Project Path="src/Kurio.Contracts/Kurio.Contracts.csproj" />
     <Project Path="src/Kurio.Server/Kurio.Server.csproj" />
     <Project Path="src/Kurio.ServiceDefaults/Kurio.ServiceDefaults.csproj" />
   </Folder>
@@ -38,5 +39,6 @@
     <File Path="docs/prd/tui-implementation.md" />
     <File Path="docs/prd/web-service-architecture.md" />
     <File Path="docs\prd\connection-resilience.md" />
+    <File Path="docs/prd/web-dashboard.md" />
   </Folder>
 </Solution>

--- a/docs/deployment/dashboard-deployment.md
+++ b/docs/deployment/dashboard-deployment.md
@@ -1,0 +1,511 @@
+# Kurio Dashboard Deployment Guide
+
+This guide covers deploying the Kurio web dashboard in various environments.
+
+## Architecture
+
+The Kurio dashboard consists of two components:
+
+1. **Kurio.Server** - ASP.NET Core API with SignalR hubs
+2. **Kurio.Web** - Blazor Server dashboard UI
+
+Both can be deployed together or separately depending on your requirements.
+
+## Deployment Options
+
+### Option 1: Same-Origin Deployment (Recommended)
+
+Host both services behind a reverse proxy under a single domain:
+
+```
+https://kurio.example.com/     → Kurio.Web
+https://kurio.example.com/api/ → Kurio.Server
+https://kurio.example.com/hubs/→ Kurio.Server (SignalR)
+```
+
+**Benefits:**
+- No CORS configuration needed
+- Simplified authentication
+- Better security posture
+- Single SSL certificate
+
+**Configuration:**
+
+See [Reverse Proxy Configuration](./reverse-proxy.md) for detailed setup.
+
+### Option 2: Cross-Origin Deployment
+
+Run services on different domains/ports:
+
+```
+https://dashboard.example.com → Kurio.Web
+https://api.example.com       → Kurio.Server
+```
+
+**Benefits:**
+- Independent scaling
+- Separate infrastructure
+- Isolated deployments
+
+**Configuration:**
+
+**Kurio.Server appsettings.json:**
+```json
+{
+  "Kurio": {
+    "Server": {
+      "AllowedOrigins": [
+        "https://dashboard.example.com"
+      ],
+      "CorsPolicy": "AllowWebClients"
+    }
+  }
+}
+```
+
+**Kurio.Web appsettings.json:**
+```json
+{
+  "KurioServer": {
+    "BaseUrl": "https://api.example.com"
+  }
+}
+```
+
+## Configuration Reference
+
+### Kurio.Server Settings
+
+| Setting | Description | Default | Required |
+|---------|-------------|---------|----------|
+| `Kurio:Server:BaseUrl` | Public URL of the server | `https://localhost:7206` | Yes |
+| `Kurio:Server:AllowedOrigins` | CORS allowed origins | `[]` | Yes (cross-origin) |
+| `Kurio:Server:CorsPolicy` | CORS policy name | `AllowWebClients` | No |
+| `Kurio:Server:Authentication:Enabled` | Enable authentication | `false` | No |
+| `Kurio:Server:Authentication:Scheme` | Auth scheme (ApiKey/Bearer) | `ApiKey` | No |
+
+### Kurio.Web Settings
+
+| Setting | Description | Default | Required |
+|---------|-------------|---------|----------|
+| `KurioServer:BaseUrl` | Kurio.Server API URL | `https://localhost:7206` | Yes |
+| `KurioServer:Hubs:Downloads` | Downloads hub path | `/hubs/downloads` | No |
+| `KurioServer:Hubs:Queue` | Queue hub path | `/hubs/queue` | No |
+| `KurioServer:Hubs:Stats` | Stats hub path | `/hubs/stats` | No |
+| `KurioServer:Authentication:Enabled` | Enable API auth | `false` | No |
+| `KurioServer:Authentication:ApiKey` | API key for server | `""` | If auth enabled |
+| `Authentication:Enabled` | Enable UI auth | `false` | No |
+
+## Authentication
+
+### Disabling Authentication (Default)
+
+For trusted internal networks or local development:
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "Authentication": {
+        "Enabled": false
+      }
+    }
+  }
+}
+```
+
+### Enabling API Key Authentication
+
+For production deployments:
+
+**1. Generate a secure API key:**
+
+```bash
+openssl rand -base64 32
+```
+
+**2. Configure Kurio.Server:**
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "Authentication": {
+        "Enabled": true,
+        "Scheme": "ApiKey"
+      }
+    }
+  }
+}
+```
+
+**3. Add environment variable or secrets:**
+
+```bash
+export KURIO__SERVER__AUTHENTICATION__APIKEY="your-generated-api-key"
+```
+
+**4. Configure Kurio.Web:**
+
+```json
+{
+  "KurioServer": {
+    "Authentication": {
+      "Enabled": true,
+      "ApiKey": "your-generated-api-key"
+    }
+  }
+}
+```
+
+**5. Enable UI authentication (optional):**
+
+```json
+{
+  "Authentication": {
+    "Enabled": true
+  }
+}
+```
+
+> **Note:** When UI authentication is enabled, users must authenticate to access the dashboard. Currently supports cookie-based authentication. External authentication providers (OAuth, OIDC) can be integrated as needed.
+
+## Environment-Specific Configuration
+
+### Development
+
+Use `appsettings.Development.json` for local development:
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "AllowedOrigins": [
+        "http://localhost:5173",
+        "http://localhost:3000",
+        "https://localhost:5001"
+      ]
+    }
+  }
+}
+```
+
+### Staging
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "BaseUrl": "https://staging.kurio.example.com",
+      "AllowedOrigins": [
+        "https://staging.kurio.example.com"
+      ],
+      "CorsPolicy": "SameOriginOnly"
+    }
+  }
+}
+```
+
+### Production
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "BaseUrl": "https://kurio.example.com",
+      "AllowedOrigins": [
+        "https://kurio.example.com"
+      ],
+      "CorsPolicy": "SameOriginOnly",
+      "Authentication": {
+        "Enabled": true,
+        "Scheme": "ApiKey"
+      }
+    },
+    "Storage": {
+      "DefaultDestination": "/var/kurio/downloads",
+      "TempDirectory": "/var/kurio/temp",
+      "StateDirectory": "/var/kurio/state"
+    }
+  }
+}
+```
+
+## Systemd Service Configuration
+
+### Kurio.Server Service
+
+Create `/etc/systemd/system/kurio-server.service`:
+
+```ini
+[Unit]
+Description=Kurio Download Manager Server
+After=network.target
+
+[Service]
+Type=notify
+WorkingDirectory=/opt/kurio/server
+ExecStart=/usr/bin/dotnet /opt/kurio/server/Kurio.Server.dll
+Restart=always
+RestartSec=10
+User=kurio
+Group=kurio
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=ASPNETCORE_URLS=http://localhost:7206
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Kurio.Web Service
+
+Create `/etc/systemd/system/kurio-web.service`:
+
+```ini
+[Unit]
+Description=Kurio Download Manager Dashboard
+After=network.target kurio-server.service
+Requires=kurio-server.service
+
+[Service]
+Type=notify
+WorkingDirectory=/opt/kurio/web
+ExecStart=/usr/bin/dotnet /opt/kurio/web/Kurio.Web.dll
+Restart=always
+RestartSec=10
+User=kurio
+Group=kurio
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=ASPNETCORE_URLS=http://localhost:5001
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Enable and Start Services
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable kurio-server kurio-web
+sudo systemctl start kurio-server kurio-web
+sudo systemctl status kurio-server kurio-web
+```
+
+## Docker Deployment
+
+### Building Images
+
+**Kurio.Server Dockerfile:**
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY ["src/Kurio.Server/Kurio.Server.csproj", "src/Kurio.Server/"]
+COPY ["src/Kurio.Core/Kurio.Core.csproj", "src/Kurio.Core/"]
+COPY ["src/Kurio.Contracts/Kurio.Contracts.csproj", "src/Kurio.Contracts/"]
+COPY ["Directory.Build.props", "Directory.Packages.props", "./"]
+RUN dotnet restore "src/Kurio.Server/Kurio.Server.csproj"
+COPY . .
+WORKDIR "/src/src/Kurio.Server"
+RUN dotnet build "Kurio.Server.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "Kurio.Server.csproj" -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+EXPOSE 7206
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Kurio.Server.dll"]
+```
+
+**Kurio.Web Dockerfile:**
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY ["src/Kurio.Web/Kurio.Web.csproj", "src/Kurio.Web/"]
+COPY ["src/Kurio.Contracts/Kurio.Contracts.csproj", "src/Kurio.Contracts/"]
+COPY ["Directory.Build.props", "Directory.Packages.props", "./"]
+RUN dotnet restore "src/Kurio.Web/Kurio.Web.csproj"
+COPY . .
+WORKDIR "/src/src/Kurio.Web"
+RUN dotnet build "Kurio.Web.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "Kurio.Web.csproj" -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+EXPOSE 5001
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Kurio.Web.dll"]
+```
+
+### docker-compose.yml
+
+See [Reverse Proxy Configuration](./reverse-proxy.md#docker-compose-deployment) for complete docker-compose setup.
+
+## Health Monitoring
+
+Both services expose health check endpoints:
+
+- **Kurio.Server**: `https://kurio.example.com/health`
+- **Kurio.Web**: Standard ASP.NET Core health checks
+
+### Health Check Responses
+
+**Healthy:**
+```json
+{
+  "status": "Healthy",
+  "checks": {
+    "download_engine": "Healthy"
+  }
+}
+```
+
+**Unhealthy:**
+```json
+{
+  "status": "Unhealthy",
+  "checks": {
+    "download_engine": "Unhealthy"
+  }
+}
+```
+
+## Performance Tuning
+
+### Connection Limits
+
+Configure maximum concurrent connections:
+
+```json
+{
+  "Kurio": {
+    "Engine": {
+      "MaxConcurrentDownloads": 5,
+      "DefaultMaxConnections": 8
+    }
+  }
+}
+```
+
+### SignalR Settings
+
+Tune SignalR for your load:
+
+```csharp
+builder.Services.AddSignalR(options =>
+{
+    options.EnableDetailedErrors = false; // Disable in production
+    options.MaximumReceiveMessageSize = 102400; // 100 KB
+    options.StreamBufferCapacity = 10;
+});
+```
+
+### Response Compression
+
+Already enabled by default. Verify in production:
+
+```bash
+curl -H "Accept-Encoding: gzip" -I https://kurio.example.com/api/downloads
+# Should include: Content-Encoding: gzip
+```
+
+## Logging
+
+### Application Logs
+
+Configure via `appsettings.json`:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.SignalR": "Information",
+      "KuriousLabs.Kurio": "Information"
+    }
+  },
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "/var/log/kurio/server-.log",
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 30
+        }
+      }
+    ]
+  }
+}
+```
+
+### Reverse Proxy Logs
+
+Monitor reverse proxy logs for connection issues:
+
+```bash
+# Nginx
+sudo tail -f /var/log/nginx/access.log /var/log/nginx/error.log
+
+# Caddy
+sudo tail -f /var/log/caddy/kurio.log
+```
+
+## Troubleshooting
+
+### Dashboard Won't Load
+
+1. Check Kurio.Server is running: `curl http://localhost:7206/health`
+2. Check Kurio.Web is running: `curl http://localhost:5001`
+3. Verify reverse proxy configuration
+4. Check firewall rules
+5. Review logs for errors
+
+### SignalR Connection Fails
+
+1. Verify WebSocket support: `curl -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" https://kurio.example.com/hubs/downloads`
+2. Check CORS configuration
+3. Verify allowed origins include the UI origin
+4. Test without authentication first
+5. Review browser console for errors
+
+### Downloads Not Starting
+
+1. Check download engine health: `/health` endpoint
+2. Verify storage paths are writable
+3. Check download limits configuration
+4. Review server logs for errors
+
+## Security Checklist
+
+- [ ] HTTPS enabled with valid certificate
+- [ ] Authentication enabled in production
+- [ ] CORS configured with specific origins (no wildcards)
+- [ ] API keys stored securely (environment variables/secrets)
+- [ ] Reverse proxy configured with security headers
+- [ ] Firewall rules restrict direct access to backend services
+- [ ] Logs configured without sensitive information
+- [ ] Regular security updates applied
+- [ ] Rate limiting configured at proxy level
+- [ ] Health check endpoints don't expose sensitive data
+
+## Support
+
+For issues or questions:
+
+- GitHub Issues: https://github.com/kiapanahi/KuriosLabs.Kurio/issues
+- Documentation: https://github.com/kiapanahi/KuriosLabs.Kurio/docs
+
+## See Also
+
+- [Reverse Proxy Configuration](./reverse-proxy.md)
+- [Configuration Reference](../configuration.md)
+- [Troubleshooting Guide](../troubleshooting.md)

--- a/docs/deployment/reverse-proxy.md
+++ b/docs/deployment/reverse-proxy.md
@@ -1,0 +1,450 @@
+# Reverse Proxy Configuration for Kurio Dashboard
+
+This guide provides sample configurations for deploying Kurio with a reverse proxy, hosting both the dashboard UI (`Kurio.Web`) and API server (`Kurio.Server`) under a single domain.
+
+## Overview
+
+The recommended deployment architecture:
+- **Kurio.Server** runs on `http://localhost:7206` (or configured port)
+- **Kurio.Web** runs on `http://localhost:5001` (or configured port)
+- **Reverse Proxy** (YARP/Nginx/Caddy) exposes both services at:
+  - `https://example.com/` → Kurio.Web (dashboard)
+  - `https://example.com/api/` → Kurio.Server (API endpoints)
+  - `https://example.com/hubs/` → Kurio.Server (SignalR hubs)
+
+This eliminates cross-origin concerns and simplifies authentication.
+
+## YARP Configuration (ASP.NET Core)
+
+YARP (Yet Another Reverse Proxy) is a .NET-based reverse proxy ideal for ASP.NET Core deployments.
+
+### 1. Install YARP
+
+```bash
+dotnet new web -n Kurio.Gateway
+cd Kurio.Gateway
+dotnet add package Yarp.ReverseProxy
+```
+
+### 2. Configure appsettings.json
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Yarp": "Information"
+    }
+  },
+  "ReverseProxy": {
+    "Routes": {
+      "api-route": {
+        "ClusterId": "kurio-server",
+        "Match": {
+          "Path": "/api/{**catch-all}"
+        }
+      },
+      "hubs-route": {
+        "ClusterId": "kurio-server",
+        "Match": {
+          "Path": "/hubs/{**catch-all}"
+        }
+      },
+      "health-route": {
+        "ClusterId": "kurio-server",
+        "Match": {
+          "Path": "/health"
+        }
+      },
+      "ui-route": {
+        "ClusterId": "kurio-web",
+        "Match": {
+          "Path": "{**catch-all}"
+        }
+      }
+    },
+    "Clusters": {
+      "kurio-server": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:7206"
+          }
+        }
+      },
+      "kurio-web": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:5001"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### 3. Configure Program.cs
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddReverseProxy()
+    .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
+
+var app = builder.Build();
+
+app.MapReverseProxy();
+
+app.Run();
+```
+
+### 4. Run the Gateway
+
+```bash
+dotnet run --urls "https://localhost:443;http://localhost:80"
+```
+
+## Nginx Configuration
+
+Nginx is a popular high-performance reverse proxy for production deployments.
+
+### nginx.conf
+
+```nginx
+http {
+    upstream kurio_server {
+        server localhost:7206;
+    }
+
+    upstream kurio_web {
+        server localhost:5001;
+    }
+
+    # WebSocket and SignalR configuration
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    server {
+        listen 80;
+        server_name kurio.example.com;
+        return 301 https://$server_name$request_uri;
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name kurio.example.com;
+
+        ssl_certificate /etc/ssl/certs/kurio.example.com.crt;
+        ssl_certificate_key /etc/ssl/private/kurio.example.com.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+
+        # API and SignalR backend
+        location /api/ {
+            proxy_pass http://kurio_server;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+            
+            # Timeouts for long-running operations
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+        }
+
+        # SignalR hubs
+        location /hubs/ {
+            proxy_pass http://kurio_server;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+            
+            # SignalR requires longer timeouts
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+        }
+
+        # Health check endpoint
+        location /health {
+            proxy_pass http://kurio_server;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Dashboard UI
+        location / {
+            proxy_pass http://kurio_web;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Blazor SignalR endpoint
+        location /_blazor {
+            proxy_pass http://kurio_web;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+    }
+}
+```
+
+### Test and Reload Nginx
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+## Caddy Configuration
+
+Caddy provides automatic HTTPS with Let's Encrypt and simple configuration.
+
+### Caddyfile
+
+```caddy
+kurio.example.com {
+    # Enable automatic HTTPS
+    tls admin@example.com
+
+    # API and SignalR backend
+    handle /api/* {
+        reverse_proxy localhost:7206 {
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto {scheme}
+            
+            # Long timeouts for downloads
+            transport http {
+                read_timeout 600s
+                write_timeout 600s
+            }
+        }
+    }
+
+    # SignalR hubs
+    handle /hubs/* {
+        reverse_proxy localhost:7206 {
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto {scheme}
+            
+            # Very long timeout for persistent connections
+            transport http {
+                read_timeout 86400s
+                write_timeout 86400s
+            }
+        }
+    }
+
+    # Health check
+    handle /health {
+        reverse_proxy localhost:7206
+    }
+
+    # Dashboard UI (default handler)
+    handle {
+        reverse_proxy localhost:5001 {
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto {scheme}
+        }
+    }
+
+    # Enable compression
+    encode gzip zstd
+
+    # Logging
+    log {
+        output file /var/log/caddy/kurio.log
+        format json
+    }
+}
+```
+
+### Run Caddy
+
+```bash
+caddy run --config Caddyfile
+# Or as a service
+sudo systemctl start caddy
+```
+
+## Kurio Configuration for Reverse Proxy
+
+When running behind a reverse proxy, update application settings:
+
+### Kurio.Server appsettings.json
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "BaseUrl": "https://kurio.example.com",
+      "AllowedOrigins": [
+        "https://kurio.example.com"
+      ],
+      "CorsPolicy": "SameOriginOnly"
+    }
+  }
+}
+```
+
+### Kurio.Web appsettings.json
+
+```json
+{
+  "KurioServer": {
+    "BaseUrl": "https://kurio.example.com",
+    "Hubs": {
+      "Downloads": "/hubs/downloads",
+      "Queue": "/hubs/queue",
+      "Stats": "/hubs/stats"
+    }
+  }
+}
+```
+
+## Local Development Without Reverse Proxy
+
+For local development, run services independently:
+
+```bash
+# Terminal 1: Start Kurio.Server
+cd src/Kurio.Server
+dotnet run
+
+# Terminal 2: Start Kurio.Web
+cd src/Kurio.Web
+dotnet run
+
+# Access dashboard at https://localhost:5001
+```
+
+Use the `appsettings.Development.json` with permissive CORS:
+
+```json
+{
+  "Kurio": {
+    "Server": {
+      "AllowedOrigins": [
+        "http://localhost:5173",
+        "http://localhost:3000",
+        "https://localhost:5001"
+      ],
+      "CorsPolicy": "AllowWebClients"
+    }
+  }
+}
+```
+
+## Docker Compose Deployment
+
+Sample `docker-compose.yml` for containerized deployment:
+
+```yaml
+version: '3.8'
+
+services:
+  kurio-server:
+    image: kurio/server:latest
+    container_name: kurio-server
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ASPNETCORE_URLS=http://+:7206
+    volumes:
+      - ./downloads:/app/downloads
+      - ./config/server-appsettings.json:/app/appsettings.Production.json:ro
+    networks:
+      - kurio-net
+
+  kurio-web:
+    image: kurio/web:latest
+    container_name: kurio-web
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Production
+      - ASPNETCORE_URLS=http://+:5001
+    volumes:
+      - ./config/web-appsettings.json:/app/appsettings.Production.json:ro
+    networks:
+      - kurio-net
+
+  nginx:
+    image: nginx:alpine
+    container_name: kurio-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/ssl:ro
+    depends_on:
+      - kurio-server
+      - kurio-web
+    networks:
+      - kurio-net
+
+networks:
+  kurio-net:
+    driver: bridge
+```
+
+## Security Considerations
+
+1. **HTTPS Only**: Always use HTTPS in production
+2. **Authentication**: Enable authentication in production environments
+3. **CORS**: Use strict same-origin policy when behind reverse proxy
+4. **Headers**: Ensure `X-Forwarded-*` headers are set correctly
+5. **Timeouts**: Configure appropriate timeouts for long-running downloads
+6. **Rate Limiting**: Consider adding rate limiting at the proxy level
+
+## Troubleshooting
+
+### SignalR Connection Fails
+
+- Verify WebSocket upgrade headers are configured
+- Check firewall allows WebSocket connections
+- Ensure timeouts are sufficient for long-lived connections
+- Validate CORS configuration matches frontend origin
+
+### Authentication Issues
+
+- Confirm API keys match between Web and Server
+- Check cookie settings if using cookie authentication
+- Verify HTTPS is used for secure cookies
+- Test with authentication disabled first
+
+### Performance Issues
+
+- Enable compression at proxy level
+- Configure appropriate connection pooling
+- Monitor backend service health
+- Consider CDN for static assets
+
+## References
+
+- [YARP Documentation](https://microsoft.github.io/reverse-proxy/)
+- [Nginx SignalR Configuration](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/)
+- [Caddy Reverse Proxy](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy)
+- [ASP.NET Core SignalR with Proxies](https://learn.microsoft.com/en-us/aspnet/core/signalr/scale)

--- a/docs/prd/kurio-web-host.md
+++ b/docs/prd/kurio-web-host.md
@@ -1,0 +1,48 @@
+# PRD: Kurio.Web Blazor Server Host (Issue #71)
+
+## Background
+The web dashboard needs its own Blazor Server host that consumes Kurio.Server via contracts and SignalR/HTTP, without referencing engine projects. This host should provide a modular shell for future pages (overview, downloads, queue, stats, settings) and handle connectivity, configuration, and auth plumbing.
+
+## Goals
+- Stand up `Kurio.Web` as a Blazor Server app targeting net10.0.
+- Consume Kurio.Server only through `Kurio.Contracts` and SignalR/HTTP endpoints.
+- Provide DI setup for HTTP/SignalR clients, configuration, and connection monitoring.
+- Ship a minimal shell (layout, nav placeholder, health status) ready for future pages.
+- Remain cross-platform and follow repo rules (central packages, versioning, minimal APIs).
+
+## Non-Goals (for this PR)
+- Implement full dashboard pages/UX (covered in #72).
+- Finalize auth model (tracked in #73); only stub hooks/config placeholders now.
+- CI/test matrix updates (tracked in #74) beyond project-level build verification.
+
+## Functional Requirements
+- Project: `src/Kurio.Web/Kurio.Web.csproj` using `Microsoft.NET.Sdk.Web`, `net10.0`, nullable enabled, implicit usings on.
+- References: only `Kurio.Contracts` (no `Kurio.Core` or engine references).
+- Hosting: Minimal Program.cs (or builder in App) wiring Blazor Server, response compression, and CORS options for dashboard; respects config.
+- Configuration: `appsettings.json` with endpoints for Kurio.Server base URL and hubs; support environment overrides.
+- DI: Typed `HttpClient` for API commands; `HubConnectionBuilder` factory for SignalR hubs (downloads, queue, stats); retry/backoff defaults.
+- Layout: Basic shell (e.g., `MainLayout`, `NavMenu` placeholder) with connection status indicator and loading/error states.
+- Error handling: Centralized exception logging; friendly UI message when server unreachable.
+- Logging: Use `LoggerMessage` pattern for host-level logs where applicable.
+- Cross-platform: No Windows-only APIs; runnable on Linux/macOS/Windows.
+
+## Architecture & Design
+- Keep boundary strict: UI consumes only contracts DTOs and hub payloads.
+- Encapsulate server connectivity in services (e.g., `KurioServerClientOptions`, `HubClientFactory`).
+- Prefer async APIs with `.ConfigureAwait(false)` in non-UI services.
+- Prepare for auth: configuration placeholders for bearer/cookie and headers; no hard-coded secrets.
+- Use centralized package management via `Directory.Packages.props` for any new dependencies.
+
+## Testing & Acceptance
+- Project builds successfully (`dotnet build` on solution or project).
+- Blazor app starts with minimal page showing connectivity placeholder (manual smoke acceptable for this PR).
+- No references to engine projects; only contracts + framework packages.
+- Configurable server URL via appsettings/environment.
+
+## Open Questions
+- Final auth mechanism (cookie vs bearer) to be decided in #73.
+- Whether to host UI and API under same origin/path; impacts CORS defaults (tracked in #73).
+
+## Deliverables
+- New `Kurio.Web` project scaffold with DI, config, layouts, and connection services.
+- Updated solution file and docs linking PRD to #71 and epic #75.

--- a/docs/prd/web-dashboard-ui-72.md
+++ b/docs/prd/web-dashboard-ui-72.md
@@ -1,0 +1,47 @@
+# PRD: Web Dashboard UI (Issue #72)
+
+## Background
+The Kurio Web host (issue #71) exists with navigation and connection plumbing but no functional dashboard UI. Issue #72 delivers the first usable dashboard: live downloads list, queue management, stats, and basic settings using the existing HTTP endpoints and SignalR hubs exposed by Kurio.Server.
+
+## Goals
+- Ship interactive pages for Overview, Downloads, Queue, Stats, and Settings in `Kurio.Web`.
+- Use SignalR hubs (`downloads`, `queue`, `stats`) for live data; use HTTP endpoints for commands and initial load where needed.
+- Support core actions: add/pause/resume/start/cancel downloads, change priority, clear completed, move queue items, update speed limits.
+- Show connection/reconnect state and friendly empty/loading/error states.
+- Keep UI strictly on `Kurio.Contracts`; no references to engine projects.
+
+## Non-Goals
+- Authentication/authorization (tracked in #73).
+- Advanced scheduling, rules, or plugin management.
+- Historical charts beyond session-level stats.
+
+## Functional Requirements
+- **Overview:** Surface key stats (active/queued/completed/failed, throughput now/avg, total bytes), recent alerts placeholder, quick links.
+- **Downloads:** Live list with status, speed, ETA, progress bar, priority, created time, actions (start/pause/resume/cancel, change priority, clear completed). Support filtering by state.
+- **Queue:** Show queue positions with move up/down/top/bottom and priority changes; live snapshot from queue hub plus HTTP commands.
+- **Stats:** Live stats snapshot and periodic updates from stats hub (counts, throughput, totals, uptime).
+- **Settings:** Read/update speed limit via `api/config/speed-limit`; show current effective limit.
+- **Connection UX:** Reconnect indicator, manual retry, informative errors when hubs/API unavailable.
+- **Contracts only:** UI consumes `KuriousLabs.Kurio.Contracts` DTOs and server HTTP responses; no engine references.
+
+## Architecture Notes
+- Reuse `HubClientFactory` for all hubs; per-page components manage connection lifecycle and request snapshots on connect.
+- `KurioApiClient` provides HTTP commands for downloads (`/api/downloads/*`), queue (`/api/queue/*`), stats (`/api/stats`), and config (`/api/config/speed-limit`).
+- Components maintain local state dictionaries keyed by download id for fast updates; apply hub deltas and refresh snapshots on reconnect.
+- Prefer async flows; show optimistic UI where reasonable and reconcile with hub updates.
+
+## Acceptance Criteria
+- All pages render meaningful data from live hubs/HTTP when Kurio.Server is running.
+- Actions (add/pause/resume/start/cancel, change priority, move queue, clear completed, update speed limit) call the correct endpoints and reflect in UI via hub updates or snapshots.
+- Connection indicator reflects Connected/Reconnecting/Disconnected states with retry control.
+- No references to `Kurio.Core` or engine projects; only `Kurio.Contracts` + framework packages.
+- Styles updated for tables, cards, badges, and responsive layout.
+
+## Dependencies
+- Kurio.Server hubs and controllers already published in the epic branch (#69/#70/#71).
+- Auth/CORS decisions pending in #73 (UI prepared for future headers/token wiring).
+
+## Risks
+- Hub method name mismatches could silently fail; ensure handlers match server method names.
+- Large download lists may need virtualization; current scope targets moderate counts.
+- Settings surface limited to speed limit until broader config endpoints are available.

--- a/docs/prd/web-dashboard.md
+++ b/docs/prd/web-dashboard.md
@@ -1,0 +1,114 @@
+# Kurio Web Dashboard PRD
+
+## Purpose
+Deliver a modular, SignalR-first web dashboard that lets users monitor and control Kurio without coupling UI code to the download engine. The dashboard must be deployable alongside `Kurio.Server` but remain cleanly separated through shared contracts and well-defined hubs/HTTP endpoints.
+
+## Goals
+- Provide live visibility into downloads, queue, throughput, errors, and health.
+- Allow core actions: add, pause/resume, retry, remove downloads; manage queue order; clear completed items; adjust basic settings (categories, proxy, concurrency).
+- Favor realtime SignalR for streaming updates; use HTTP for idempotent commands and initial snapshots.
+- Keep UI modular: UI only consumes contracts; no engine references; boundary enforced via `Kurio.Contracts`.
+- Operate cross-platform (Windows/macOS/Linux) and support same-origin or reverse-proxy hosting.
+
+## Non-Goals (for this iteration)
+- Full authentication/authorization redesign (basic auth wiring only, detailed policies later).
+- Advanced scheduling, rules, or plugin management.
+- Browser extension integration (separate track).
+- Offline-first caching of large data sets; focus on connected experience with graceful reconnect.
+
+## Target Users & Use Cases
+- Power users running Kurio headless on a NAS/server who need a browser dashboard.
+- Desktop users who prefer web UI over TUI for managing multiple downloads.
+- Operators monitoring throughput, errors, and queue health in real time.
+
+## Success Metrics
+- Downloads list renders within 1.5s on initial load (50 items baseline).
+- Realtime updates visible within 500ms of server event under normal load.
+- Reconnect after transient network loss within 5s with state resynced.
+- No UI/engine coupling: UI builds with only contracts + HTTP/SignalR clients.
+
+## Scope & Features
+- **Overview:** Key stats (active/queued/completed counts, throughput now/avg, failure count, recent alerts), server health indicator.
+- **Downloads list:** Filter/sort, per-item progress, speed, ETA, size, status, actions (pause/resume/retry/remove), bulk clear completed.
+- **Queue:** Position, priority changes (move up/down/top/bottom), scheduled items if present.
+- **Add download:** URL entry, optional category/destination, connection count, checksum (if provided), proxy toggle.
+- **Stats:** Throughput history (short window), aggregate totals, per-protocol counts if available.
+- **Logs/alerts:** Recent failures/retries with timestamps and messages; link to affected download.
+- **Settings (MVP):** Category defaults, proxy on/off + endpoint, concurrency/segment defaults; display-only advanced settings is acceptable.
+- **Cross-cutting UX:**
+  - Connection state indicator (online/reconnecting/offline) with backoff.
+  - Empty/loading/error states for each page.
+  - Responsive layout (desktop first, usable on tablets/phones).
+  - Basic a11y: keyboard nav, focus order, aria labels on key controls.
+
+## Architecture & Communication
+- **Topology:** `Kurio.Web` (Blazor Server) talks to `Kurio.Server` via SignalR + HTTP. Contracts live in `Kurio.Contracts` referenced by both. Reverse proxy can host under one domain/path; dev can run cross-origin with CORS enabled.
+- **Realtime (SignalR hubs):**
+  - `DownloadsHub`: 
+    - Server->client: `DownloadSnapshot` (initial batch), `DownloadUpdated`, `DownloadRemoved`, `DownloadCompleted`, `DownloadFailed`, `BulkCleared`.
+    - Client->server: `SubscribeDownloads(filters)`, `UnsubscribeDownloads`, optional `RequestSnapshot`.
+  - `QueueHub`:
+    - Server->client: `QueueSnapshot`, `QueuePositionChanged`, `QueueItemAdded/Removed`.
+    - Client->server: `SubscribeQueue`, `UnsubscribeQueue`.
+  - `StatsHub`:
+    - Server->client: `StatsSnapshot`, `StatsUpdated` (throughput/aggregate), optional `AlertRaised`.
+    - Client->server: `SubscribeStats`, `UnsubscribeStats`.
+  - All hubs use contracts DTOs; payloads sized for UI (no engine objects). Support resumable subscriptions and replay of latest snapshot on reconnect.
+- **HTTP (minimal APIs):**
+  - Commands: `POST /downloads` (add), `POST /downloads/{id}/pause`, `.../resume`, `.../retry`, `DELETE /downloads/{id}?removeFiles=bool`, `POST /downloads/{id}/priority`, `POST /downloads/pause-all`, `POST /downloads/clear-completed`.
+  - Reads/snapshots: `GET /downloads?filter=...`, `GET /downloads/{id}`, `GET /queue`, `GET /stats`, `GET /settings`.
+  - Settings: `POST /settings` for basic dashboard-exposed fields (categories, proxy, concurrency defaults).
+  - Health: `GET /health` for UI connectivity checks.
+- **State model:** Initial page load fetches HTTP snapshot(s), then subscribes to hubs for live deltas. On reconnect, request fresh snapshots before applying live updates to avoid drift.
+- **Error handling:** Graceful degradation to HTTP polling is out-of-scope; UI should surface reconnect/backoff and allow manual retry.
+
+## Data Contracts (initial set)
+Defined in `Kurio.Contracts` and shared by server + UI:
+- `DownloadSummary`: id, name, url host, category, size, downloaded bytes, percent, status, speed, eta, connections, createdAt, lastUpdated, checksum present?, errors count.
+- `DownloadProgressUpdate`: id, downloaded bytes, speed, eta, percent, active connections, timestamp.
+- `DownloadStatusChange`: id, oldStatus, newStatus, reason?, message?, finishedAt?
+- `QueueItem`: downloadId, position, priority, scheduledAt?, addedAt.
+- `StatsSnapshot`: active/queued/completed/failed counts, current throughput, avg throughput (short window), total bytes downloaded, uptime.
+- `Alert`: severity, message, downloadId?, occurredAt.
+- `SettingsSummary`: category defaults, proxy enabled + endpoint, max concurrent downloads, default connections per download, default segment size if exposed.
+- `AddDownloadCommand`, `Pause/Resume/Retry/Remove/ChangePriority` commands; `SettingsUpdateCommand`.
+
+## UX & Interaction Notes
+- Show per-item actions inline; confirm destructive remove.
+- Use optimistic UI for pause/resume/retry; reconcile with server responses.
+- Virtualize lists for performance beyond ~200 items.
+- Preserve filters/sorts across reconnect when possible.
+
+## Auth, CORS, Deployment
+- Prefer same-origin hosting (reverse proxy `Kurio.Web` under `Kurio.Server` domain/path). For dev cross-origin, enable CORS for HTTPS localhost origins; allow credentials.
+- Auth model: cookie or bearer per server decision; Blazor Server auth plumbing should integrate later—MVP can assume trusted local dev if auth not yet in place.
+- Document reverse-proxy examples (YARP/Nginx) and environment variables for base addresses.
+
+## Telemetry & Logging
+- Instrument SignalR connection lifecycle (connect/reconnect/disconnect, failures) and key commands success/failure (add/pause/resume/remove).
+- Surface errors in UI with actionable messages; log with correlation ids where possible.
+- Basic client-side perf timing for initial load and hub connect is desirable (manual note acceptable if not automated).
+
+## Testing Expectations
+- Unit: DTO validation/serialization, small mapping helpers.
+- Integration: hubs (subscribe, receive updates), HTTP commands happy-path + basic errors.
+- UI smoke (bUnit/Playwright): initial load shows snapshot; actions (add/pause/resume/remove) update UI; reconnect indicator toggles when server offline.
+
+## Dependencies & Sequencing
+1) #69 Contracts library (DTOs/hub signatures).
+2) #70 Server hubs + HTTP surfaces using contracts.
+3) #71 Blazor host shell that consumes those surfaces.
+4) #72 Dashboard pages wired to SignalR/HTTP.
+5) #73 Auth/CORS/deployment story finalized.
+6) #74 Tests/CI wired for new projects.
+
+## Risks & Open Questions
+- Auth model not finalized; may impact hosting and hub negotiation.
+- Large download lists: may need pagination or server-side filtering; current scope assumes modest counts with virtualization.
+- Throughput history source: confirm if engine provides time-series or if server must aggregate.
+- Logs/alerts feed source: clarify existing logging surface vs new stream.
+
+## Acceptance Criteria (for issue #68)
+- This PRD lives at `docs/prd/web-dashboard.md` with the sections above.
+- Documents pages, communication model (SignalR + HTTP), data contracts needed, auth/deployment notes, testing expectations, dependencies, and open questions.
+- Reviewed and approved for the dashboard epic.

--- a/src/Kurio.AppHost/AppHost.cs
+++ b/src/Kurio.AppHost/AppHost.cs
@@ -1,5 +1,10 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<Projects.Kurio_Server>("server");
+var server = builder.AddProject<Projects.Kurio_Server>("server");
+
+var web = builder.AddProject<Projects.Kurio_Web>("web");
+
+web.WithReference(server)
+    .WaitFor(server);
 
 builder.Build().Run();

--- a/src/Kurio.AppHost/Kurio.AppHost.csproj
+++ b/src/Kurio.AppHost/Kurio.AppHost.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Kurio.Server\Kurio.Server.csproj" />
+    <ProjectReference Include="..\Kurio.Web\Kurio.Web.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Kurio.Contracts/Downloads/DownloadModels.cs
+++ b/src/Kurio.Contracts/Downloads/DownloadModels.cs
@@ -1,0 +1,156 @@
+using System.Text.Json.Serialization;
+
+namespace KuriousLabs.Kurio.Contracts.Downloads;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DownloadState
+{
+    Created,
+    Queued,
+    Analyzing,
+    Downloading,
+    Paused,
+    Completed,
+    Failed,
+    Cancelled
+}
+
+[Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DownloadStateFilter
+{
+    None = 0,
+    Created = 1 << 0,
+    Queued = 1 << 1,
+    Analyzing = 1 << 2,
+    Downloading = 1 << 3,
+    Paused = 1 << 4,
+    Completed = 1 << 5,
+    Failed = 1 << 6,
+    Cancelled = 1 << 7,
+    Active = Queued | Analyzing | Downloading,
+    All = Created | Queued | Analyzing | Downloading | Paused | Completed | Failed | Cancelled
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DownloadPriority
+{
+    Low = 0,
+    Normal = 1,
+    High = 2,
+    Critical = 3
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum DownloadErrorCategory
+{
+    Network,
+    Http,
+    DiskIo,
+    Protocol,
+    ResourceNotFound,
+    Authentication,
+    RateLimiting,
+    Unknown
+}
+
+public sealed record DownloadFailureInfo
+{
+    public DownloadErrorCategory Category { get; init; }
+
+    public string Message { get; init; } = string.Empty;
+
+    public string? Details { get; init; }
+
+    public int? StatusCode { get; init; }
+
+    public int? RetryCount { get; init; }
+
+    public string? Source { get; init; }
+
+    public DateTimeOffset OccurredAt { get; init; }
+}
+
+public sealed record DownloadSummary
+{
+    public Guid Id { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+
+    public string Url { get; init; } = string.Empty;
+
+    public string? Category { get; init; }
+
+    public long? TotalBytes { get; init; }
+
+    public long DownloadedBytes { get; init; }
+
+    public double? PercentComplete { get; init; }
+
+    public DownloadState State { get; init; }
+
+    public long? BytesPerSecond { get; init; }
+
+    public TimeSpan? EstimatedTimeRemaining { get; init; }
+
+    public int ActiveConnections { get; init; }
+
+    public DownloadPriority Priority { get; init; } = DownloadPriority.Normal;
+
+    public bool HasChecksum { get; init; }
+
+    public DownloadFailureInfo? LastError { get; init; }
+
+    public DateTimeOffset CreatedAt { get; init; }
+
+    public DateTimeOffset? LastUpdatedAt { get; init; }
+
+    public string? DestinationPath { get; init; }
+}
+
+public sealed record DownloadProgressUpdate
+{
+    public Guid Id { get; init; }
+
+    public long DownloadedBytes { get; init; }
+
+    public long? TotalBytes { get; init; }
+
+    public double? PercentComplete { get; init; }
+
+    public long? BytesPerSecond { get; init; }
+
+    public TimeSpan? EstimatedTimeRemaining { get; init; }
+
+    public int ActiveConnections { get; init; }
+
+    public DateTimeOffset Timestamp { get; init; }
+}
+
+public sealed record DownloadStatusChange
+{
+    public Guid Id { get; init; }
+
+    public DownloadState PreviousState { get; init; }
+
+    public DownloadState CurrentState { get; init; }
+
+    public string? Reason { get; init; }
+
+    public string? Message { get; init; }
+
+    public DownloadFailureInfo? Failure { get; init; }
+
+    public DateTimeOffset Timestamp { get; init; }
+}
+
+public sealed record DownloadSubscriptionRequest
+{
+    public DownloadStateFilter States { get; init; } = DownloadStateFilter.All;
+
+    public string? Category { get; init; }
+
+    public int? Limit { get; init; }
+
+    public bool IncludeCompleted { get; init; }
+}

--- a/src/Kurio.Contracts/Downloads/DownloadRequests.cs
+++ b/src/Kurio.Contracts/Downloads/DownloadRequests.cs
@@ -1,0 +1,38 @@
+namespace KuriousLabs.Kurio.Contracts.Downloads;
+
+public sealed record AddDownloadRequest
+{
+    public string Url { get; init; } = string.Empty;
+
+    public string? FileName { get; init; }
+
+    public string? Category { get; init; }
+
+    public string? DestinationPath { get; init; }
+
+    public int? MaxConnections { get; init; }
+
+    public string? Checksum { get; init; }
+
+    public string? ChecksumAlgorithm { get; init; }
+
+    public bool? UseProxy { get; init; }
+
+    public string? ProxyAddress { get; init; }
+
+    public int? SegmentSizeBytes { get; init; }
+}
+
+public sealed record ChangePriorityRequest
+{
+    public DownloadPriority Priority { get; init; } = DownloadPriority.Normal;
+}
+
+public sealed record DownloadFilterRequest
+{
+    public DownloadStateFilter States { get; init; } = DownloadStateFilter.All;
+
+    public string? Category { get; init; }
+
+    public int? Limit { get; init; }
+}

--- a/src/Kurio.Contracts/Hubs/DownloadsHubContracts.cs
+++ b/src/Kurio.Contracts/Hubs/DownloadsHubContracts.cs
@@ -1,0 +1,27 @@
+using KuriousLabs.Kurio.Contracts.Downloads;
+
+namespace KuriousLabs.Kurio.Contracts.Hubs;
+
+public interface IDownloadsHub
+{
+    Task SubscribeDownloadsAsync(DownloadSubscriptionRequest request, CancellationToken cancellationToken = default);
+
+    Task UnsubscribeDownloadsAsync(CancellationToken cancellationToken = default);
+
+    Task RequestSnapshotAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IDownloadsClient
+{
+    Task ReceiveSnapshotAsync(IReadOnlyList<DownloadSummary> downloads);
+
+    Task DownloadUpdatedAsync(DownloadSummary download);
+
+    Task DownloadProgressedAsync(DownloadProgressUpdate progress);
+
+    Task DownloadStatusChangedAsync(DownloadStatusChange change);
+
+    Task DownloadRemovedAsync(Guid downloadId);
+
+    Task DownloadsClearedAsync(IReadOnlyCollection<Guid> downloadIds);
+}

--- a/src/Kurio.Contracts/Hubs/DownloadsHubContracts.cs
+++ b/src/Kurio.Contracts/Hubs/DownloadsHubContracts.cs
@@ -4,11 +4,11 @@ namespace KuriousLabs.Kurio.Contracts.Hubs;
 
 public interface IDownloadsHub
 {
-    Task SubscribeDownloadsAsync(DownloadSubscriptionRequest request, CancellationToken cancellationToken = default);
+    Task SubscribeDownloadsAsync(DownloadSubscriptionRequest request);
 
-    Task UnsubscribeDownloadsAsync(CancellationToken cancellationToken = default);
+    Task UnsubscribeDownloadsAsync();
 
-    Task RequestSnapshotAsync(CancellationToken cancellationToken = default);
+    Task RequestSnapshotAsync();
 }
 
 public interface IDownloadsClient

--- a/src/Kurio.Contracts/Hubs/QueueHubContracts.cs
+++ b/src/Kurio.Contracts/Hubs/QueueHubContracts.cs
@@ -1,0 +1,23 @@
+using KuriousLabs.Kurio.Contracts.Queue;
+
+namespace KuriousLabs.Kurio.Contracts.Hubs;
+
+public interface IQueueHub
+{
+    Task SubscribeQueueAsync(CancellationToken cancellationToken = default);
+
+    Task UnsubscribeQueueAsync(CancellationToken cancellationToken = default);
+
+    Task RequestQueueSnapshotAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IQueueClient
+{
+    Task QueueSnapshotAsync(IReadOnlyList<QueueItem> items);
+
+    Task QueueItemEnqueuedAsync(QueueItem item);
+
+    Task QueueItemRemovedAsync(Guid downloadId);
+
+    Task QueuePositionChangedAsync(QueuePositionChanged change);
+}

--- a/src/Kurio.Contracts/Hubs/QueueHubContracts.cs
+++ b/src/Kurio.Contracts/Hubs/QueueHubContracts.cs
@@ -4,11 +4,11 @@ namespace KuriousLabs.Kurio.Contracts.Hubs;
 
 public interface IQueueHub
 {
-    Task SubscribeQueueAsync(CancellationToken cancellationToken = default);
+    Task SubscribeQueueAsync();
 
-    Task UnsubscribeQueueAsync(CancellationToken cancellationToken = default);
+    Task UnsubscribeQueueAsync();
 
-    Task RequestQueueSnapshotAsync(CancellationToken cancellationToken = default);
+    Task RequestQueueSnapshotAsync();
 }
 
 public interface IQueueClient

--- a/src/Kurio.Contracts/Hubs/StatsHubContracts.cs
+++ b/src/Kurio.Contracts/Hubs/StatsHubContracts.cs
@@ -1,0 +1,21 @@
+using KuriousLabs.Kurio.Contracts.Stats;
+
+namespace KuriousLabs.Kurio.Contracts.Hubs;
+
+public interface IStatsHub
+{
+    Task SubscribeStatsAsync(CancellationToken cancellationToken = default);
+
+    Task UnsubscribeStatsAsync(CancellationToken cancellationToken = default);
+
+    Task RequestStatsSnapshotAsync(CancellationToken cancellationToken = default);
+}
+
+public interface IStatsClient
+{
+    Task StatsSnapshotAsync(StatsSnapshot snapshot);
+
+    Task StatsUpdatedAsync(StatsSnapshot snapshot);
+
+    Task AlertRaisedAsync(Alert alert);
+}

--- a/src/Kurio.Contracts/Hubs/StatsHubContracts.cs
+++ b/src/Kurio.Contracts/Hubs/StatsHubContracts.cs
@@ -4,11 +4,11 @@ namespace KuriousLabs.Kurio.Contracts.Hubs;
 
 public interface IStatsHub
 {
-    Task SubscribeStatsAsync(CancellationToken cancellationToken = default);
+    Task SubscribeStatsAsync();
 
-    Task UnsubscribeStatsAsync(CancellationToken cancellationToken = default);
+    Task UnsubscribeStatsAsync();
 
-    Task RequestStatsSnapshotAsync(CancellationToken cancellationToken = default);
+    Task RequestStatsSnapshotAsync();
 }
 
 public interface IStatsClient

--- a/src/Kurio.Contracts/Kurio.Contracts.csproj
+++ b/src/Kurio.Contracts/Kurio.Contracts.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>true</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>KuriousLabs.Kurio.Contracts</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/src/Kurio.Contracts/Queue/QueueContracts.cs
+++ b/src/Kurio.Contracts/Queue/QueueContracts.cs
@@ -1,0 +1,34 @@
+using KuriousLabs.Kurio.Contracts.Downloads;
+
+namespace KuriousLabs.Kurio.Contracts.Queue;
+
+public sealed record QueueItem
+{
+    public Guid DownloadId { get; init; }
+
+    public string Name { get; init; } = string.Empty;
+
+    public string? Category { get; init; }
+
+    public int Position { get; init; }
+
+    public DownloadPriority Priority { get; init; } = DownloadPriority.Normal;
+
+    public DateTimeOffset AddedAt { get; init; }
+
+    public DateTimeOffset? ScheduledAt { get; init; }
+}
+
+public sealed record QueueSnapshot
+{
+    public IReadOnlyList<QueueItem> Items { get; init; } = Array.Empty<QueueItem>();
+}
+
+public sealed record QueuePositionChanged
+{
+    public Guid DownloadId { get; init; }
+
+    public int Position { get; init; }
+
+    public DownloadPriority Priority { get; init; } = DownloadPriority.Normal;
+}

--- a/src/Kurio.Contracts/Settings/SettingsContracts.cs
+++ b/src/Kurio.Contracts/Settings/SettingsContracts.cs
@@ -1,0 +1,31 @@
+namespace KuriousLabs.Kurio.Contracts.Settings;
+
+public sealed record SettingsSummary
+{
+    public bool ProxyEnabled { get; init; }
+
+    public string? ProxyAddress { get; init; }
+
+    public int MaxConcurrentDownloads { get; init; }
+
+    public int DefaultConnectionsPerDownload { get; init; }
+
+    public int? DefaultSegmentSizeBytes { get; init; }
+
+    public string? DefaultCategory { get; init; }
+}
+
+public sealed record SettingsUpdateRequest
+{
+    public bool? ProxyEnabled { get; init; }
+
+    public string? ProxyAddress { get; init; }
+
+    public int? MaxConcurrentDownloads { get; init; }
+
+    public int? DefaultConnectionsPerDownload { get; init; }
+
+    public int? DefaultSegmentSizeBytes { get; init; }
+
+    public string? DefaultCategory { get; init; }
+}

--- a/src/Kurio.Contracts/Stats/StatsContracts.cs
+++ b/src/Kurio.Contracts/Stats/StatsContracts.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Serialization;
+
+namespace KuriousLabs.Kurio.Contracts.Stats;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AlertSeverity
+{
+    Info,
+    Warning,
+    Error,
+    Critical
+}
+
+public sealed record Alert
+{
+    public AlertSeverity Severity { get; init; } = AlertSeverity.Info;
+
+    public string Message { get; init; } = string.Empty;
+
+    public Guid? DownloadId { get; init; }
+
+    public string? Source { get; init; }
+
+    public DateTimeOffset OccurredAt { get; init; }
+}
+
+public sealed record StatsSnapshot
+{
+    public int ActiveCount { get; init; }
+
+    public int QueuedCount { get; init; }
+
+    public int CompletedCount { get; init; }
+
+    public int FailedCount { get; init; }
+
+    public long CurrentThroughputBytesPerSecond { get; init; }
+
+    public long AverageThroughputBytesPerSecond { get; init; }
+
+    public long TotalBytesDownloaded { get; init; }
+
+    public DateTimeOffset? StartedAt { get; init; }
+}

--- a/src/Kurio.Server/Controllers/DownloadsController.cs
+++ b/src/Kurio.Server/Controllers/DownloadsController.cs
@@ -1,8 +1,14 @@
+using System.Linq;
+
+using KuriousLabs.Kurio.Contracts.Hubs;
 using KuriousLabs.Kurio.Core.Abstractions;
 using KuriousLabs.Kurio.Core.Models;
+using KuriousLabs.Kurio.Server.Hubs;
+using KuriousLabs.Kurio.Server.Mappers;
 using KuriousLabs.Kurio.Server.Models;
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 
 namespace KuriousLabs.Kurio.Server.Controllers;
 
@@ -15,13 +21,22 @@ namespace KuriousLabs.Kurio.Server.Controllers;
 public class DownloadsController : ControllerBase
 {
     private readonly IDownloadEngine _engine;
+    private readonly IDownloadQueueManager _queueManager;
+    private readonly IHubContext<DownloadHub, IDownloadsClient> _downloadsHubContext;
+    private readonly IHubContext<QueueHub, IQueueClient> _queueHubContext;
     private readonly ILogger<DownloadsController> _logger;
 
     public DownloadsController(
         IDownloadEngine engine,
+        IDownloadQueueManager queueManager,
+        IHubContext<DownloadHub, IDownloadsClient> downloadsHubContext,
+        IHubContext<QueueHub, IQueueClient> queueHubContext,
         ILogger<DownloadsController> logger)
     {
         _engine = engine;
+        _queueManager = queueManager;
+        _downloadsHubContext = downloadsHubContext;
+        _queueHubContext = queueHubContext;
         _logger = logger;
     }
 
@@ -51,7 +66,7 @@ public class DownloadsController : ControllerBase
             var task = await _engine.AddDownloadAsync(
                 uri,
                 request.ToDownloadOptions(),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
 
             // Set priority if different from default
             if (request.Priority != DownloadPriority.Normal)
@@ -60,6 +75,8 @@ public class DownloadsController : ControllerBase
             }
 
             var response = DownloadResponse.FromTask(task);
+            await BroadcastDownloadUpdateAsync(task, cancellationToken).ConfigureAwait(false);
+            await BroadcastQueueSnapshotAsync(cancellationToken).ConfigureAwait(false);
             return CreatedAtAction(nameof(GetDownload), new { id = task.Id }, response);
         }
         catch (Exception ex)
@@ -124,7 +141,9 @@ public class DownloadsController : ControllerBase
     {
         try
         {
-            await _engine.StartDownloadAsync(id, cancellationToken);
+            await _engine.StartDownloadAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastDownloadUpdateIfExistsAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastQueueSnapshotAsync(cancellationToken).ConfigureAwait(false);
             return NoContent();
         }
         catch (InvalidOperationException ex)
@@ -158,7 +177,9 @@ public class DownloadsController : ControllerBase
     {
         try
         {
-            await _engine.PauseDownloadAsync(id, cancellationToken);
+            await _engine.PauseDownloadAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastDownloadUpdateIfExistsAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastQueueSnapshotAsync(cancellationToken).ConfigureAwait(false);
             return NoContent();
         }
         catch (InvalidOperationException ex)
@@ -192,7 +213,9 @@ public class DownloadsController : ControllerBase
     {
         try
         {
-            await _engine.ResumeDownloadAsync(id, cancellationToken);
+            await _engine.ResumeDownloadAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastDownloadUpdateIfExistsAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastQueueSnapshotAsync(cancellationToken).ConfigureAwait(false);
             return NoContent();
         }
         catch (InvalidOperationException ex)
@@ -229,7 +252,9 @@ public class DownloadsController : ControllerBase
     {
         try
         {
-            await _engine.CancelDownloadAsync(id, removeFiles, cancellationToken);
+            await _engine.CancelDownloadAsync(id, removeFiles, cancellationToken).ConfigureAwait(false);
+            await BroadcastDownloadRemovedAsync(id, cancellationToken).ConfigureAwait(false);
+            await BroadcastQueueSnapshotAsync(cancellationToken).ConfigureAwait(false);
             return NoContent();
         }
         catch (Exception ex)
@@ -262,6 +287,8 @@ public class DownloadsController : ControllerBase
                 title: "Download not found or not queued");
         }
 
+        await BroadcastDownloadUpdateIfExistsAsync(id, HttpContext.RequestAborted).ConfigureAwait(false);
+        await BroadcastQueueSnapshotAsync(HttpContext.RequestAborted).ConfigureAwait(false);
         return NoContent();
     }
 
@@ -274,7 +301,15 @@ public class DownloadsController : ControllerBase
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     public async Task<ActionResult<int>> PauseAll(CancellationToken cancellationToken)
     {
-        var count = await _engine.PauseAllAsync(cancellationToken);
+        var count = await _engine.PauseAllAsync(cancellationToken).ConfigureAwait(false);
+
+        var active = _engine.GetDownloads(DownloadStateFilter.Active).ToList();
+        foreach (var task in active)
+        {
+            await BroadcastDownloadUpdateAsync(task, cancellationToken).ConfigureAwait(false);
+        }
+
+        await BroadcastQueueSnapshotAsync(cancellationToken).ConfigureAwait(false);
         return Ok(count);
     }
 
@@ -283,9 +318,19 @@ public class DownloadsController : ControllerBase
     /// </summary>
     [HttpPost("clear-completed")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    public IActionResult ClearCompleted()
+    public async Task<IActionResult> ClearCompleted(CancellationToken cancellationToken)
     {
+        var completedIds = _engine.GetDownloads(DownloadStateFilter.Completed)
+            .Select(d => d.Id)
+            .ToList();
+
         _engine.ClearCompleted();
+
+        if (completedIds.Count > 0)
+        {
+            await BroadcastDownloadsClearedAsync(completedIds, cancellationToken).ConfigureAwait(false);
+        }
+
         return NoContent();
     }
 
@@ -308,5 +353,47 @@ public class DownloadsController : ControllerBase
             CompletedDownloads = allDownloads.Count(d => d.State == DownloadState.Completed),
             FailedDownloads = allDownloads.Count(d => d.State == DownloadState.Failed)
         });
+    }
+
+    private async Task BroadcastDownloadUpdateAsync(IDownloadTask task, CancellationToken cancellationToken)
+    {
+        var summary = task.ToContract();
+        await _downloadsHubContext.Clients.Group(DownloadHub.GroupName)
+            .DownloadUpdatedAsync(summary)
+            .ConfigureAwait(false);
+    }
+
+    private async Task BroadcastDownloadUpdateIfExistsAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var task = _engine.GetDownload(id);
+        if (task != null)
+        {
+            await BroadcastDownloadUpdateAsync(task, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task BroadcastDownloadRemovedAsync(Guid id, CancellationToken cancellationToken)
+    {
+        await _downloadsHubContext.Clients.Group(DownloadHub.GroupName)
+            .DownloadRemovedAsync(id)
+            .ConfigureAwait(false);
+    }
+
+    private async Task BroadcastDownloadsClearedAsync(IReadOnlyCollection<Guid> ids, CancellationToken cancellationToken)
+    {
+        await _downloadsHubContext.Clients.Group(DownloadHub.GroupName)
+            .DownloadsClearedAsync(ids)
+            .ConfigureAwait(false);
+    }
+
+    private async Task BroadcastQueueSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var snapshot = _queueManager.GetQueuedTasks()
+            .Select((task, index) => task.ToContract(index + 1))
+            .ToList();
+
+        await _queueHubContext.Clients.Group(QueueHub.GroupName)
+            .QueueSnapshotAsync(snapshot)
+            .ConfigureAwait(false);
     }
 }

--- a/src/Kurio.Server/Controllers/DownloadsController.cs
+++ b/src/Kurio.Server/Controllers/DownloadsController.cs
@@ -276,7 +276,7 @@ public class DownloadsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public IActionResult ChangePriority(Guid id, [FromBody] ChangePriorityRequest request)
+    public async Task<IActionResult> ChangePriority(Guid id, [FromBody] ChangePriorityRequest request)
     {
         var success = _engine.ChangePriority(id, request.Priority);
         if (!success)

--- a/src/Kurio.Server/Controllers/QueueController.cs
+++ b/src/Kurio.Server/Controllers/QueueController.cs
@@ -1,0 +1,145 @@
+using System.Linq;
+
+using KuriousLabs.Kurio.Contracts.Queue;
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Server.Hubs;
+using KuriousLabs.Kurio.Server.Mappers;
+using ContractChangePriorityRequest = KuriousLabs.Kurio.Contracts.Downloads.ChangePriorityRequest;
+using KuriousLabs.Kurio.Core.Abstractions;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+
+namespace KuriousLabs.Kurio.Server.Controllers;
+
+[ApiController]
+[Route("api/queue")]
+[Produces("application/json")]
+public class QueueController : ControllerBase
+{
+    private readonly IDownloadQueueManager _queueManager;
+    private readonly IHubContext<QueueHub, IQueueClient> _queueHubContext;
+    private readonly ILogger<QueueController> _logger;
+
+    public QueueController(
+        IDownloadQueueManager queueManager,
+        IHubContext<QueueHub, IQueueClient> queueHubContext,
+        ILogger<QueueController> logger)
+    {
+        _queueManager = queueManager;
+        _queueHubContext = queueHubContext;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(List<QueueItem>), StatusCodes.Status200OK)]
+    public ActionResult<List<QueueItem>> GetQueue()
+    {
+        var snapshot = BuildSnapshot();
+        return Ok(snapshot);
+    }
+
+    [HttpPost("{id:guid}/priority")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ChangePriorityAsync(
+        Guid id,
+        [FromBody] ContractChangePriorityRequest request,
+        CancellationToken cancellationToken)
+    {
+        var success = _queueManager.ChangePriority(id, request.Priority.ToCorePriority());
+        if (!success)
+        {
+            return Problem(
+                $"Cannot change priority for download {id}",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Download not found or not queued");
+        }
+
+        await BroadcastSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/move-up")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> MoveUpAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (!_queueManager.MoveUp(id))
+        {
+            return Problem(
+                $"Cannot move download {id} up",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Download not found or already at top");
+        }
+
+        await BroadcastSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/move-down")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> MoveDownAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (!_queueManager.MoveDown(id))
+        {
+            return Problem(
+                $"Cannot move download {id} down",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Download not found or already at bottom");
+        }
+
+        await BroadcastSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/move-top")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> MoveToTopAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (!_queueManager.MoveToTop(id))
+        {
+            return Problem(
+                $"Cannot move download {id} to top",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Download not found or already at top");
+        }
+
+        await BroadcastSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    [HttpPost("{id:guid}/move-bottom")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> MoveToBottomAsync(Guid id, CancellationToken cancellationToken)
+    {
+        if (!_queueManager.MoveToBottom(id))
+        {
+            return Problem(
+                $"Cannot move download {id} to bottom",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Download not found or already at bottom");
+        }
+
+        await BroadcastSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        return NoContent();
+    }
+
+    private List<QueueItem> BuildSnapshot()
+    {
+        return _queueManager.GetQueuedTasks()
+            .Select((task, index) => task.ToContract(index + 1))
+            .ToList();
+    }
+
+    private async Task BroadcastSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var snapshot = BuildSnapshot();
+        await _queueHubContext.Clients.Group(QueueHub.GroupName)
+            .QueueSnapshotAsync(snapshot)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Kurio.Server/Controllers/StatsController.cs
+++ b/src/Kurio.Server/Controllers/StatsController.cs
@@ -1,0 +1,33 @@
+using KuriousLabs.Kurio.Contracts.Stats;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Mappers;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace KuriousLabs.Kurio.Server.Controllers;
+
+[ApiController]
+[Route("api/stats")]
+[Produces("application/json")]
+public class StatsController : ControllerBase
+{
+    private readonly IStatisticsService _statisticsService;
+    private readonly IDownloadQueueManager _queueManager;
+
+    public StatsController(
+        IStatisticsService statisticsService,
+        IDownloadQueueManager queueManager)
+    {
+        _statisticsService = statisticsService;
+        _queueManager = queueManager;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(typeof(StatsSnapshot), StatusCodes.Status200OK)]
+    public async Task<ActionResult<StatsSnapshot>> GetStatsAsync(CancellationToken cancellationToken)
+    {
+        var stats = await _statisticsService.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+        var snapshot = stats.ToContract(_queueManager);
+        return Ok(snapshot);
+    }
+}

--- a/src/Kurio.Server/Hubs/DownloadHub.cs
+++ b/src/Kurio.Server/Hubs/DownloadHub.cs
@@ -1,15 +1,19 @@
+using System.Linq;
+
+using KuriousLabs.Kurio.Contracts.Downloads;
+using KuriousLabs.Kurio.Contracts.Hubs;
 using KuriousLabs.Kurio.Core.Abstractions;
-using KuriousLabs.Kurio.Server.Models;
+using KuriousLabs.Kurio.Server.Mappers;
+using CoreModels = KuriousLabs.Kurio.Core.Models;
 
 using Microsoft.AspNetCore.SignalR;
 
 namespace KuriousLabs.Kurio.Server.Hubs;
 
-/// <summary>
-///     SignalR hub for real-time download updates and operations.
-/// </summary>
-public class DownloadHub : Hub
+public sealed class DownloadHub : Hub<IDownloadsClient>, IDownloadsHub
 {
+    public const string GroupName = "downloads";
+
     private readonly IDownloadEngine _engine;
     private readonly ILogger<DownloadHub> _logger;
 
@@ -21,64 +25,51 @@ public class DownloadHub : Hub
         _logger = logger;
     }
 
-    /// <summary>
-    ///     Subscribe to progress updates for a specific task or all tasks.
-    /// </summary>
-    /// <param name="taskId">Optional task ID to filter progress updates. If null, receives all progress.</param>
-    public async Task SubscribeToProgress(Guid? taskId = null)
+    public async Task SubscribeDownloadsAsync(DownloadSubscriptionRequest request, CancellationToken cancellationToken = default)
     {
-        var connectionId = Context.ConnectionId;
-        _logger.LogInformation("Client {ConnectionId} subscribed to progress for task {TaskId}",
-            connectionId, taskId?.ToString() ?? "all");
+        _logger.LogInformation("Client {ConnectionId} subscribed to downloads", Context.ConnectionId);
 
-        // Note: Progress streaming is handled by ProgressBroadcaster
-        await Clients.Caller.SendAsync("Subscribed", taskId);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+        await SendSnapshotAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    ///     Unsubscribe from progress updates.
-    /// </summary>
-    public async Task UnsubscribeFromProgress()
+    public async Task UnsubscribeDownloadsAsync(CancellationToken cancellationToken = default)
     {
-        var connectionId = Context.ConnectionId;
-        _logger.LogInformation("Client {ConnectionId} unsubscribed from progress", connectionId);
-
-        await Clients.Caller.SendAsync("Unsubscribed");
+        _logger.LogInformation("Client {ConnectionId} unsubscribed from downloads", Context.ConnectionId);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    ///     Get download details for a specific task.
-    /// </summary>
-    /// <param name="id">Download task ID.</param>
-    /// <returns>Download details.</returns>
-    public async Task<DownloadResponse> GetDownload(Guid id)
+    public async Task RequestSnapshotAsync(CancellationToken cancellationToken = default)
     {
-        var task = _engine.GetDownload(id);
-        if (task == null)
+        _logger.LogInformation("Client {ConnectionId} requested snapshot", Context.ConnectionId);
+        await SendSnapshotAsync(null, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SendSnapshotAsync(DownloadSubscriptionRequest? request, CancellationToken cancellationToken)
+    {
+        var filter = request?.States ?? DownloadStateFilter.All;
+        var tasks = _engine.GetDownloads(filter.ToCoreFilter())
+            .Where(task => request?.Category is null || task.Options.Category == request.Category)
+            .OrderByDescending(task => task.Priority)
+            .ThenBy(task => task.CreatedAt)
+            .ToList();
+
+        if (request?.IncludeCompleted == false)
         {
-            throw new HubException($"Download {id} not found");
+            tasks = tasks
+                .Where(t => t.State != CoreModels.DownloadState.Completed)
+                .ToList();
         }
 
-        return await Task.FromResult(DownloadResponse.FromTask(task));
-    }
-
-    public override async Task OnConnectedAsync()
-    {
-        _logger.LogInformation("Client {ConnectionId} connected", Context.ConnectionId);
-        await base.OnConnectedAsync();
-    }
-
-    public override async Task OnDisconnectedAsync(Exception? exception)
-    {
-        if (exception != null)
+        if (request?.Limit is { } limit && limit > 0)
         {
-            _logger.LogWarning(exception, "Client {ConnectionId} disconnected with error", Context.ConnectionId);
-        }
-        else
-        {
-            _logger.LogInformation("Client {ConnectionId} disconnected", Context.ConnectionId);
+            tasks = tasks.Take(limit).ToList();
         }
 
-        await base.OnDisconnectedAsync(exception);
+        var snapshot = tasks
+            .Select(t => t.ToContract())
+            .ToList();
+
+        await Clients.Caller.ReceiveSnapshotAsync(snapshot).ConfigureAwait(false);
     }
 }

--- a/src/Kurio.Server/Hubs/DownloadHub.cs
+++ b/src/Kurio.Server/Hubs/DownloadHub.cs
@@ -25,27 +25,27 @@ public sealed class DownloadHub : Hub<IDownloadsClient>, IDownloadsHub
         _logger = logger;
     }
 
-    public async Task SubscribeDownloadsAsync(DownloadSubscriptionRequest request, CancellationToken cancellationToken = default)
+    public async Task SubscribeDownloadsAsync(DownloadSubscriptionRequest request)
     {
         _logger.LogInformation("Client {ConnectionId} subscribed to downloads", Context.ConnectionId);
 
-        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
-        await SendSnapshotAsync(request, cancellationToken).ConfigureAwait(false);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName).ConfigureAwait(false);
+        await SendSnapshotAsync(request).ConfigureAwait(false);
     }
 
-    public async Task UnsubscribeDownloadsAsync(CancellationToken cancellationToken = default)
+    public async Task UnsubscribeDownloadsAsync()
     {
         _logger.LogInformation("Client {ConnectionId} unsubscribed from downloads", Context.ConnectionId);
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName).ConfigureAwait(false);
     }
 
-    public async Task RequestSnapshotAsync(CancellationToken cancellationToken = default)
+    public async Task RequestSnapshotAsync()
     {
         _logger.LogInformation("Client {ConnectionId} requested snapshot", Context.ConnectionId);
-        await SendSnapshotAsync(null, cancellationToken).ConfigureAwait(false);
+        await SendSnapshotAsync(null).ConfigureAwait(false);
     }
 
-    private async Task SendSnapshotAsync(DownloadSubscriptionRequest? request, CancellationToken cancellationToken)
+    private async Task SendSnapshotAsync(DownloadSubscriptionRequest? request)
     {
         var filter = request?.States ?? DownloadStateFilter.All;
         var tasks = _engine.GetDownloads(filter.ToCoreFilter())

--- a/src/Kurio.Server/Hubs/QueueHub.cs
+++ b/src/Kurio.Server/Hubs/QueueHub.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Contracts.Queue;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Mappers;
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace KuriousLabs.Kurio.Server.Hubs;
+
+public sealed class QueueHub : Hub<IQueueClient>, IQueueHub
+{
+    public const string GroupName = "queue";
+
+    private readonly IDownloadQueueManager _queueManager;
+    private readonly ILogger<QueueHub> _logger;
+
+    public QueueHub(
+        IDownloadQueueManager queueManager,
+        ILogger<QueueHub> logger)
+    {
+        _queueManager = queueManager;
+        _logger = logger;
+    }
+
+    public async Task SubscribeQueueAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Client {ConnectionId} subscribed to queue", Context.ConnectionId);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UnsubscribeQueueAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Client {ConnectionId} unsubscribed from queue", Context.ConnectionId);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RequestQueueSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Client {ConnectionId} requested queue snapshot", Context.ConnectionId);
+        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SendSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var queueItems = _queueManager.GetQueuedTasks()
+            .Select((task, index) => task.ToContract(index + 1))
+            .ToList();
+
+        await Clients.Caller.QueueSnapshotAsync(queueItems).ConfigureAwait(false);
+    }
+}

--- a/src/Kurio.Server/Hubs/QueueHub.cs
+++ b/src/Kurio.Server/Hubs/QueueHub.cs
@@ -24,26 +24,26 @@ public sealed class QueueHub : Hub<IQueueClient>, IQueueHub
         _logger = logger;
     }
 
-    public async Task SubscribeQueueAsync(CancellationToken cancellationToken = default)
+    public async Task SubscribeQueueAsync()
     {
         _logger.LogInformation("Client {ConnectionId} subscribed to queue", Context.ConnectionId);
-        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
-        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName).ConfigureAwait(false);
+        await SendSnapshotAsync().ConfigureAwait(false);
     }
 
-    public async Task UnsubscribeQueueAsync(CancellationToken cancellationToken = default)
+    public async Task UnsubscribeQueueAsync()
     {
         _logger.LogInformation("Client {ConnectionId} unsubscribed from queue", Context.ConnectionId);
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName).ConfigureAwait(false);
     }
 
-    public async Task RequestQueueSnapshotAsync(CancellationToken cancellationToken = default)
+    public async Task RequestQueueSnapshotAsync()
     {
         _logger.LogInformation("Client {ConnectionId} requested queue snapshot", Context.ConnectionId);
-        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        await SendSnapshotAsync().ConfigureAwait(false);
     }
 
-    private async Task SendSnapshotAsync(CancellationToken cancellationToken)
+    private async Task SendSnapshotAsync()
     {
         var queueItems = _queueManager.GetQueuedTasks()
             .Select((task, index) => task.ToContract(index + 1))

--- a/src/Kurio.Server/Hubs/StatsHub.cs
+++ b/src/Kurio.Server/Hubs/StatsHub.cs
@@ -1,0 +1,52 @@
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Mappers;
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace KuriousLabs.Kurio.Server.Hubs;
+
+public sealed class StatsHub : Hub<IStatsClient>, IStatsHub
+{
+    public const string GroupName = "stats";
+
+    private readonly IStatisticsService _statisticsService;
+    private readonly IDownloadQueueManager _queueManager;
+    private readonly ILogger<StatsHub> _logger;
+
+    public StatsHub(
+        IStatisticsService statisticsService,
+        IDownloadQueueManager queueManager,
+        ILogger<StatsHub> logger)
+    {
+        _statisticsService = statisticsService;
+        _queueManager = queueManager;
+        _logger = logger;
+    }
+
+    public async Task SubscribeStatsAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Client {ConnectionId} subscribed to stats", Context.ConnectionId);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UnsubscribeStatsAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Client {ConnectionId} unsubscribed from stats", Context.ConnectionId);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RequestStatsSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Client {ConnectionId} requested stats snapshot", Context.ConnectionId);
+        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SendSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var stats = await _statisticsService.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+        var snapshot = stats.ToContract(_queueManager);
+        await Clients.Caller.StatsSnapshotAsync(snapshot).ConfigureAwait(false);
+    }
+}

--- a/src/Kurio.Server/Hubs/StatsHub.cs
+++ b/src/Kurio.Server/Hubs/StatsHub.cs
@@ -24,28 +24,28 @@ public sealed class StatsHub : Hub<IStatsClient>, IStatsHub
         _logger = logger;
     }
 
-    public async Task SubscribeStatsAsync(CancellationToken cancellationToken = default)
+    public async Task SubscribeStatsAsync()
     {
         _logger.LogInformation("Client {ConnectionId} subscribed to stats", Context.ConnectionId);
-        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
-        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupName).ConfigureAwait(false);
+        await SendSnapshotAsync().ConfigureAwait(false);
     }
 
-    public async Task UnsubscribeStatsAsync(CancellationToken cancellationToken = default)
+    public async Task UnsubscribeStatsAsync()
     {
         _logger.LogInformation("Client {ConnectionId} unsubscribed from stats", Context.ConnectionId);
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName, cancellationToken).ConfigureAwait(false);
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, GroupName).ConfigureAwait(false);
     }
 
-    public async Task RequestStatsSnapshotAsync(CancellationToken cancellationToken = default)
+    public async Task RequestStatsSnapshotAsync()
     {
         _logger.LogInformation("Client {ConnectionId} requested stats snapshot", Context.ConnectionId);
-        await SendSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        await SendSnapshotAsync().ConfigureAwait(false);
     }
 
-    private async Task SendSnapshotAsync(CancellationToken cancellationToken)
+    private async Task SendSnapshotAsync()
     {
-        var stats = await _statisticsService.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+        var stats = await _statisticsService.GetStatisticsAsync(Context.ConnectionAborted).ConfigureAwait(false);
         var snapshot = stats.ToContract(_queueManager);
         await Clients.Caller.StatsSnapshotAsync(snapshot).ConfigureAwait(false);
     }

--- a/src/Kurio.Server/Kurio.Server.csproj
+++ b/src/Kurio.Server/Kurio.Server.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Kurio.Core\Kurio.Core.csproj"/>
     <ProjectReference Include="..\Kurio.ServiceDefaults\Kurio.ServiceDefaults.csproj"/>
+    <ProjectReference Include="..\Kurio.Contracts\Kurio.Contracts.csproj"/>
   </ItemGroup>
 
 </Project>

--- a/src/Kurio.Server/Mappers/DownloadContractMapper.cs
+++ b/src/Kurio.Server/Mappers/DownloadContractMapper.cs
@@ -1,0 +1,192 @@
+using KuriousLabs.Kurio.Contracts.Downloads;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Core.Models;
+
+namespace KuriousLabs.Kurio.Server.Mappers;
+
+public static class DownloadContractMapper
+{
+    public static DownloadSummary ToContract(this IDownloadTask task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        return new DownloadSummary
+        {
+            Id = task.Id,
+            Name = task.FileName,
+            Url = task.Url.ToString(),
+            Category = task.Options.Category,
+            TotalBytes = task.FileSize > 0 ? task.FileSize : null,
+            DownloadedBytes = task.Progress.BytesDownloaded,
+            PercentComplete = task.Progress.TotalBytes > 0
+                ? task.Progress.Percentage
+                : null,
+            State = MapState(task.State),
+            BytesPerSecond = task.Progress.BytesPerSecond,
+            EstimatedTimeRemaining = task.Progress.EstimatedTimeRemaining,
+            ActiveConnections = task.Progress.ActiveConnections,
+            Priority = MapPriority(task.Priority),
+            HasChecksum = task.Options.Checksum is not null
+                || !string.IsNullOrWhiteSpace(task.Options.ExpectedChecksum),
+            LastError = MapError(task.LastError),
+            CreatedAt = task.CreatedAt,
+            LastUpdatedAt = task.Progress.Timestamp,
+            DestinationPath = task.Options.DestinationDirectory
+        };
+    }
+
+    public static DownloadProgressUpdate ToProgressUpdate(this DownloadProgress progress)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        return new DownloadProgressUpdate
+        {
+            Id = progress.TaskId,
+            DownloadedBytes = progress.BytesDownloaded,
+            TotalBytes = progress.TotalBytes > 0 ? progress.TotalBytes : null,
+            PercentComplete = progress.TotalBytes > 0
+                ? progress.Percentage
+                : null,
+            BytesPerSecond = progress.BytesPerSecond,
+            EstimatedTimeRemaining = progress.EstimatedTimeRemaining,
+            ActiveConnections = progress.ActiveConnections,
+            Timestamp = progress.Timestamp
+        };
+    }
+
+    public static KuriousLabs.Kurio.Core.Models.DownloadStateFilter ToCoreFilter(this DownloadStateFilter filter)
+    {
+        if (filter == DownloadStateFilter.All)
+        {
+            return KuriousLabs.Kurio.Core.Models.DownloadStateFilter.All;
+        }
+
+        if (filter == DownloadStateFilter.None)
+        {
+            return KuriousLabs.Kurio.Core.Models.DownloadStateFilter.None;
+        }
+
+        KuriousLabs.Kurio.Core.Models.DownloadStateFilter mapped = 0;
+
+        if (filter.HasFlag(DownloadStateFilter.Created))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Created;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Queued))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Queued;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Analyzing))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Analyzing;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Downloading))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Downloading;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Paused))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Paused;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Completed))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Completed;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Failed))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Failed;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Cancelled))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Cancelled;
+        }
+
+        if (filter.HasFlag(DownloadStateFilter.Active))
+        {
+            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Active;
+        }
+
+        return mapped;
+    }
+
+    private static DownloadFailureInfo? MapError(DownloadError? error)
+    {
+        if (error is null)
+        {
+            return null;
+        }
+
+        return new DownloadFailureInfo
+        {
+            Category = MapErrorCategory(error.Category),
+            Message = error.UserFriendlyMessage ?? error.Message,
+            Details = error.StackTrace,
+            StatusCode = error.HttpStatusCode,
+            RetryCount = null,
+            Source = error.ExceptionType,
+            OccurredAt = error.Timestamp
+        };
+    }
+
+    private static DownloadErrorCategory MapErrorCategory(Core.Models.DownloadErrorCategory category)
+    {
+        return category switch
+        {
+            Core.Models.DownloadErrorCategory.Network => DownloadErrorCategory.Network,
+            Core.Models.DownloadErrorCategory.Http => DownloadErrorCategory.Http,
+            Core.Models.DownloadErrorCategory.DiskIo => DownloadErrorCategory.DiskIo,
+            Core.Models.DownloadErrorCategory.Protocol => DownloadErrorCategory.Protocol,
+            Core.Models.DownloadErrorCategory.ResourceNotFound => DownloadErrorCategory.ResourceNotFound,
+            Core.Models.DownloadErrorCategory.Authentication => DownloadErrorCategory.Authentication,
+            Core.Models.DownloadErrorCategory.RateLimiting => DownloadErrorCategory.RateLimiting,
+            _ => DownloadErrorCategory.Unknown
+        };
+    }
+
+    internal static DownloadPriority MapPriority(Core.Models.DownloadPriority priority)
+    {
+        return priority switch
+        {
+            Core.Models.DownloadPriority.Low => DownloadPriority.Low,
+            Core.Models.DownloadPriority.Normal => DownloadPriority.Normal,
+            Core.Models.DownloadPriority.High => DownloadPriority.High,
+            Core.Models.DownloadPriority.Critical => DownloadPriority.Critical,
+            _ => DownloadPriority.Normal
+        };
+    }
+
+    public static Core.Models.DownloadPriority ToCorePriority(this DownloadPriority priority)
+    {
+        return priority switch
+        {
+            DownloadPriority.Low => Core.Models.DownloadPriority.Low,
+            DownloadPriority.Normal => Core.Models.DownloadPriority.Normal,
+            DownloadPriority.High => Core.Models.DownloadPriority.High,
+            DownloadPriority.Critical => Core.Models.DownloadPriority.Critical,
+            _ => Core.Models.DownloadPriority.Normal
+        };
+    }
+
+    private static DownloadState MapState(Core.Models.DownloadState state)
+    {
+        return state switch
+        {
+            Core.Models.DownloadState.Created => DownloadState.Created,
+            Core.Models.DownloadState.Queued => DownloadState.Queued,
+            Core.Models.DownloadState.Analyzing => DownloadState.Analyzing,
+            Core.Models.DownloadState.Downloading => DownloadState.Downloading,
+            Core.Models.DownloadState.Paused => DownloadState.Paused,
+            Core.Models.DownloadState.Completed => DownloadState.Completed,
+            Core.Models.DownloadState.Failed => DownloadState.Failed,
+            Core.Models.DownloadState.Cancelled => DownloadState.Cancelled,
+            _ => DownloadState.Created
+        };
+    }
+}

--- a/src/Kurio.Server/Mappers/DownloadContractMapper.cs
+++ b/src/Kurio.Server/Mappers/DownloadContractMapper.cs
@@ -1,16 +1,16 @@
-using KuriousLabs.Kurio.Contracts.Downloads;
 using KuriousLabs.Kurio.Core.Abstractions;
-using KuriousLabs.Kurio.Core.Models;
+using CoreModels = KuriousLabs.Kurio.Core.Models;
+using ContractDownloads = KuriousLabs.Kurio.Contracts.Downloads;
 
 namespace KuriousLabs.Kurio.Server.Mappers;
 
 public static class DownloadContractMapper
 {
-    public static DownloadSummary ToContract(this IDownloadTask task)
+    public static ContractDownloads.DownloadSummary ToContract(this IDownloadTask task)
     {
         ArgumentNullException.ThrowIfNull(task);
 
-        return new DownloadSummary
+        return new ContractDownloads.DownloadSummary
         {
             Id = task.Id,
             Name = task.FileName,
@@ -35,11 +35,11 @@ public static class DownloadContractMapper
         };
     }
 
-    public static DownloadProgressUpdate ToProgressUpdate(this DownloadProgress progress)
+    public static ContractDownloads.DownloadProgressUpdate ToProgressUpdate(this CoreModels.DownloadProgress progress)
     {
         ArgumentNullException.ThrowIfNull(progress);
 
-        return new DownloadProgressUpdate
+        return new ContractDownloads.DownloadProgressUpdate
         {
             Id = progress.TaskId,
             DownloadedBytes = progress.BytesDownloaded,
@@ -54,76 +54,76 @@ public static class DownloadContractMapper
         };
     }
 
-    public static KuriousLabs.Kurio.Core.Models.DownloadStateFilter ToCoreFilter(this DownloadStateFilter filter)
+    public static CoreModels.DownloadStateFilter ToCoreFilter(this ContractDownloads.DownloadStateFilter filter)
     {
-        if (filter == DownloadStateFilter.All)
+        if (filter == ContractDownloads.DownloadStateFilter.All)
         {
-            return KuriousLabs.Kurio.Core.Models.DownloadStateFilter.All;
+            return CoreModels.DownloadStateFilter.All;
         }
 
-        if (filter == DownloadStateFilter.None)
+        if (filter == ContractDownloads.DownloadStateFilter.None)
         {
-            return KuriousLabs.Kurio.Core.Models.DownloadStateFilter.None;
+            return CoreModels.DownloadStateFilter.None;
         }
 
-        KuriousLabs.Kurio.Core.Models.DownloadStateFilter mapped = 0;
+        CoreModels.DownloadStateFilter mapped = 0;
 
-        if (filter.HasFlag(DownloadStateFilter.Created))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Created))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Created;
+            mapped |= CoreModels.DownloadStateFilter.Created;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Queued))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Queued))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Queued;
+            mapped |= CoreModels.DownloadStateFilter.Queued;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Analyzing))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Analyzing))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Analyzing;
+            mapped |= CoreModels.DownloadStateFilter.Analyzing;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Downloading))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Downloading))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Downloading;
+            mapped |= CoreModels.DownloadStateFilter.Downloading;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Paused))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Paused))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Paused;
+            mapped |= CoreModels.DownloadStateFilter.Paused;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Completed))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Completed))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Completed;
+            mapped |= CoreModels.DownloadStateFilter.Completed;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Failed))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Failed))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Failed;
+            mapped |= CoreModels.DownloadStateFilter.Failed;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Cancelled))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Cancelled))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Cancelled;
+            mapped |= CoreModels.DownloadStateFilter.Cancelled;
         }
 
-        if (filter.HasFlag(DownloadStateFilter.Active))
+        if (filter.HasFlag(ContractDownloads.DownloadStateFilter.Active))
         {
-            mapped |= KuriousLabs.Kurio.Core.Models.DownloadStateFilter.Active;
+            mapped |= CoreModels.DownloadStateFilter.Active;
         }
 
         return mapped;
     }
 
-    private static DownloadFailureInfo? MapError(DownloadError? error)
+    private static ContractDownloads.DownloadFailureInfo? MapError(CoreModels.DownloadError? error)
     {
         if (error is null)
         {
             return null;
         }
 
-        return new DownloadFailureInfo
+        return new ContractDownloads.DownloadFailureInfo
         {
             Category = MapErrorCategory(error.Category),
             Message = error.UserFriendlyMessage ?? error.Message,
@@ -135,58 +135,58 @@ public static class DownloadContractMapper
         };
     }
 
-    private static DownloadErrorCategory MapErrorCategory(Core.Models.DownloadErrorCategory category)
+    private static ContractDownloads.DownloadErrorCategory MapErrorCategory(CoreModels.DownloadErrorCategory category)
     {
         return category switch
         {
-            Core.Models.DownloadErrorCategory.Network => DownloadErrorCategory.Network,
-            Core.Models.DownloadErrorCategory.Http => DownloadErrorCategory.Http,
-            Core.Models.DownloadErrorCategory.DiskIo => DownloadErrorCategory.DiskIo,
-            Core.Models.DownloadErrorCategory.Protocol => DownloadErrorCategory.Protocol,
-            Core.Models.DownloadErrorCategory.ResourceNotFound => DownloadErrorCategory.ResourceNotFound,
-            Core.Models.DownloadErrorCategory.Authentication => DownloadErrorCategory.Authentication,
-            Core.Models.DownloadErrorCategory.RateLimiting => DownloadErrorCategory.RateLimiting,
-            _ => DownloadErrorCategory.Unknown
+            CoreModels.DownloadErrorCategory.Network => ContractDownloads.DownloadErrorCategory.Network,
+            CoreModels.DownloadErrorCategory.Http => ContractDownloads.DownloadErrorCategory.Http,
+            CoreModels.DownloadErrorCategory.DiskIo => ContractDownloads.DownloadErrorCategory.DiskIo,
+            CoreModels.DownloadErrorCategory.Protocol => ContractDownloads.DownloadErrorCategory.Protocol,
+            CoreModels.DownloadErrorCategory.ResourceNotFound => ContractDownloads.DownloadErrorCategory.ResourceNotFound,
+            CoreModels.DownloadErrorCategory.Authentication => ContractDownloads.DownloadErrorCategory.Authentication,
+            CoreModels.DownloadErrorCategory.RateLimiting => ContractDownloads.DownloadErrorCategory.RateLimiting,
+            _ => ContractDownloads.DownloadErrorCategory.Unknown
         };
     }
 
-    internal static DownloadPriority MapPriority(Core.Models.DownloadPriority priority)
+    internal static ContractDownloads.DownloadPriority MapPriority(CoreModels.DownloadPriority priority)
     {
         return priority switch
         {
-            Core.Models.DownloadPriority.Low => DownloadPriority.Low,
-            Core.Models.DownloadPriority.Normal => DownloadPriority.Normal,
-            Core.Models.DownloadPriority.High => DownloadPriority.High,
-            Core.Models.DownloadPriority.Critical => DownloadPriority.Critical,
-            _ => DownloadPriority.Normal
+            CoreModels.DownloadPriority.Low => ContractDownloads.DownloadPriority.Low,
+            CoreModels.DownloadPriority.Normal => ContractDownloads.DownloadPriority.Normal,
+            CoreModels.DownloadPriority.High => ContractDownloads.DownloadPriority.High,
+            CoreModels.DownloadPriority.Critical => ContractDownloads.DownloadPriority.Critical,
+            _ => ContractDownloads.DownloadPriority.Normal
         };
     }
 
-    public static Core.Models.DownloadPriority ToCorePriority(this DownloadPriority priority)
+    public static CoreModels.DownloadPriority ToCorePriority(this ContractDownloads.DownloadPriority priority)
     {
         return priority switch
         {
-            DownloadPriority.Low => Core.Models.DownloadPriority.Low,
-            DownloadPriority.Normal => Core.Models.DownloadPriority.Normal,
-            DownloadPriority.High => Core.Models.DownloadPriority.High,
-            DownloadPriority.Critical => Core.Models.DownloadPriority.Critical,
-            _ => Core.Models.DownloadPriority.Normal
+            ContractDownloads.DownloadPriority.Low => CoreModels.DownloadPriority.Low,
+            ContractDownloads.DownloadPriority.Normal => CoreModels.DownloadPriority.Normal,
+            ContractDownloads.DownloadPriority.High => CoreModels.DownloadPriority.High,
+            ContractDownloads.DownloadPriority.Critical => CoreModels.DownloadPriority.Critical,
+            _ => CoreModels.DownloadPriority.Normal
         };
     }
 
-    private static DownloadState MapState(Core.Models.DownloadState state)
+    private static ContractDownloads.DownloadState MapState(CoreModels.DownloadState state)
     {
         return state switch
         {
-            Core.Models.DownloadState.Created => DownloadState.Created,
-            Core.Models.DownloadState.Queued => DownloadState.Queued,
-            Core.Models.DownloadState.Analyzing => DownloadState.Analyzing,
-            Core.Models.DownloadState.Downloading => DownloadState.Downloading,
-            Core.Models.DownloadState.Paused => DownloadState.Paused,
-            Core.Models.DownloadState.Completed => DownloadState.Completed,
-            Core.Models.DownloadState.Failed => DownloadState.Failed,
-            Core.Models.DownloadState.Cancelled => DownloadState.Cancelled,
-            _ => DownloadState.Created
+            CoreModels.DownloadState.Created => ContractDownloads.DownloadState.Created,
+            CoreModels.DownloadState.Queued => ContractDownloads.DownloadState.Queued,
+            CoreModels.DownloadState.Analyzing => ContractDownloads.DownloadState.Analyzing,
+            CoreModels.DownloadState.Downloading => ContractDownloads.DownloadState.Downloading,
+            CoreModels.DownloadState.Paused => ContractDownloads.DownloadState.Paused,
+            CoreModels.DownloadState.Completed => ContractDownloads.DownloadState.Completed,
+            CoreModels.DownloadState.Failed => ContractDownloads.DownloadState.Failed,
+            CoreModels.DownloadState.Cancelled => ContractDownloads.DownloadState.Cancelled,
+            _ => ContractDownloads.DownloadState.Created
         };
     }
 }

--- a/src/Kurio.Server/Mappers/QueueContractMapper.cs
+++ b/src/Kurio.Server/Mappers/QueueContractMapper.cs
@@ -1,0 +1,23 @@
+using KuriousLabs.Kurio.Contracts.Queue;
+using KuriousLabs.Kurio.Core.Abstractions;
+
+namespace KuriousLabs.Kurio.Server.Mappers;
+
+public static class QueueContractMapper
+{
+    public static QueueItem ToContract(this IDownloadTask task, int position)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        return new QueueItem
+        {
+            DownloadId = task.Id,
+            Name = task.FileName,
+            Category = task.Options.Category,
+            Position = position,
+            Priority = DownloadContractMapper.MapPriority(task.Priority),
+            AddedAt = task.CreatedAt,
+            ScheduledAt = null
+        };
+    }
+}

--- a/src/Kurio.Server/Mappers/StatsContractMapper.cs
+++ b/src/Kurio.Server/Mappers/StatsContractMapper.cs
@@ -1,0 +1,28 @@
+using KuriousLabs.Kurio.Contracts.Stats;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Core.Models;
+
+namespace KuriousLabs.Kurio.Server.Mappers;
+
+public static class StatsContractMapper
+{
+    public static StatsSnapshot ToContract(
+        this DownloadStatistics statistics,
+        IDownloadQueueManager queueManager)
+    {
+        ArgumentNullException.ThrowIfNull(statistics);
+        ArgumentNullException.ThrowIfNull(queueManager);
+
+        return new StatsSnapshot
+        {
+            ActiveCount = queueManager.ActiveDownloadsCount,
+            QueuedCount = queueManager.QueuedDownloadsCount,
+            CompletedCount = statistics.AllTimeCompletedDownloads,
+            FailedCount = statistics.AllTimeFailedDownloads,
+            CurrentThroughputBytesPerSecond = statistics.AverageDownloadSpeed,
+            AverageThroughputBytesPerSecond = statistics.AverageDownloadSpeed,
+            TotalBytesDownloaded = statistics.AllTimeBytesDownloaded,
+            StartedAt = statistics.SessionStartedAt
+        };
+    }
+}

--- a/src/Kurio.Server/Program.cs
+++ b/src/Kurio.Server/Program.cs
@@ -42,6 +42,8 @@ builder.Services.AddKurioDownloadEngine();
 builder.Services.AddHostedService<DownloadEngineHostedService>();
 builder.Services.AddSingleton<ProgressBroadcaster>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ProgressBroadcaster>());
+builder.Services.AddSingleton<StatsBroadcaster>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<StatsBroadcaster>());
 
 // Add CORS
 var allowedOrigins = builder.Configuration
@@ -83,6 +85,8 @@ app.UseAuthorization();
 
 app.MapControllers();
 app.MapHub<DownloadHub>("/hubs/downloads");
+app.MapHub<QueueHub>("/hubs/queue");
+app.MapHub<StatsHub>("/hubs/stats");
 app.MapHealthChecks("/health");
 
 // SSE endpoint for progress streaming

--- a/src/Kurio.Server/Program.cs
+++ b/src/Kurio.Server/Program.cs
@@ -45,16 +45,33 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<ProgressBroadcaste
 builder.Services.AddSingleton<StatsBroadcaster>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<StatsBroadcaster>());
 
-// Add CORS
+// Add CORS with enhanced configuration for dashboard and third-party clients
 var allowedOrigins = builder.Configuration
     .GetSection("Kurio:Server:AllowedOrigins")
     .Get<string[]>() ?? ["http://localhost:5173", "http://localhost:3000"];
 
-builder.Services.AddCors(options => options.AddPolicy("AllowWebClients", policy =>
-    policy.WithOrigins(allowedOrigins)
-        .AllowAnyHeader()
-        .AllowAnyMethod()
-        .AllowCredentials()));
+var corsPolicy = builder.Configuration.GetValue<string>("Kurio:Server:CorsPolicy") ?? "AllowWebClients";
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(corsPolicy, policy =>
+    {
+        policy.WithOrigins(allowedOrigins)
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials()
+            .SetIsOriginAllowedToAllowWildcardSubdomains();
+    });
+
+    // Stricter policy for production reverse-proxy scenarios
+    options.AddPolicy("SameOriginOnly", policy =>
+    {
+        policy.WithOrigins(builder.Configuration.GetValue<string>("Kurio:Server:BaseUrl") ?? "https://localhost:7206")
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
 
 // Add response compression
 builder.Services.AddResponseCompression(options => options.EnableForHttps = true);
@@ -80,7 +97,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseResponseCompression();
 app.UseHttpsRedirection();
-app.UseCors("AllowWebClients");
+app.UseCors(corsPolicy);
 app.UseAuthorization();
 
 app.MapControllers();

--- a/src/Kurio.Server/Services/ProgressBroadcaster.cs
+++ b/src/Kurio.Server/Services/ProgressBroadcaster.cs
@@ -1,5 +1,7 @@
+using KuriousLabs.Kurio.Contracts.Hubs;
 using KuriousLabs.Kurio.Core.Abstractions;
 using KuriousLabs.Kurio.Server.Hubs;
+using KuriousLabs.Kurio.Server.Mappers;
 
 using Microsoft.AspNetCore.SignalR;
 
@@ -11,12 +13,12 @@ namespace KuriousLabs.Kurio.Server.Services;
 public class ProgressBroadcaster : BackgroundService
 {
     private readonly IDownloadEngine _engine;
-    private readonly IHubContext<DownloadHub> _hubContext;
+    private readonly IHubContext<DownloadHub, IDownloadsClient> _hubContext;
     private readonly ILogger<ProgressBroadcaster> _logger;
 
     public ProgressBroadcaster(
         IDownloadEngine engine,
-        IHubContext<DownloadHub> hubContext,
+        IHubContext<DownloadHub, IDownloadsClient> hubContext,
         ILogger<ProgressBroadcaster> logger)
     {
         _engine = engine;
@@ -34,11 +36,10 @@ public class ProgressBroadcaster : BackgroundService
             {
                 try
                 {
-                    // Broadcast to all connected SignalR clients
-                    await _hubContext.Clients.All.SendAsync(
-                        "ProgressUpdate",
-                        progress,
-                        stoppingToken);
+                    var update = progress.ToProgressUpdate();
+                    await _hubContext.Clients.Group(DownloadHub.GroupName)
+                        .DownloadProgressedAsync(update)
+                        .ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Kurio.Server/Services/StatsBroadcaster.cs
+++ b/src/Kurio.Server/Services/StatsBroadcaster.cs
@@ -1,0 +1,62 @@
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Hubs;
+using KuriousLabs.Kurio.Server.Mappers;
+
+using Microsoft.AspNetCore.SignalR;
+
+namespace KuriousLabs.Kurio.Server.Services;
+
+public class StatsBroadcaster : BackgroundService
+{
+    private static readonly TimeSpan BroadcastInterval = TimeSpan.FromSeconds(5);
+
+    private readonly IStatisticsService _statisticsService;
+    private readonly IDownloadQueueManager _queueManager;
+    private readonly IHubContext<StatsHub, IStatsClient> _hubContext;
+    private readonly ILogger<StatsBroadcaster> _logger;
+
+    public StatsBroadcaster(
+        IStatisticsService statisticsService,
+        IDownloadQueueManager queueManager,
+        IHubContext<StatsHub, IStatsClient> hubContext,
+        ILogger<StatsBroadcaster> logger)
+    {
+        _statisticsService = statisticsService;
+        _queueManager = queueManager;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Stats broadcaster started");
+
+        try
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await BroadcastAsync(stoppingToken).ConfigureAwait(false);
+                await Task.Delay(BroadcastInterval, stoppingToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Stats broadcaster stopped");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Stats broadcaster encountered an error");
+        }
+    }
+
+    private async Task BroadcastAsync(CancellationToken cancellationToken)
+    {
+        var stats = await _statisticsService.GetStatisticsAsync(cancellationToken).ConfigureAwait(false);
+        var snapshot = stats.ToContract(_queueManager);
+
+        await _hubContext.Clients.Group(StatsHub.GroupName)
+            .StatsUpdatedAsync(snapshot)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Kurio.Server/appsettings.Development.json
+++ b/src/Kurio.Server/appsettings.Development.json
@@ -11,8 +11,10 @@
       "AllowedOrigins": [
         "http://localhost:5173",
         "http://localhost:3000",
-        "http://localhost:8080"
+        "http://localhost:8080",
+        "https://localhost:5001"
       ],
+      "CorsPolicy": "AllowWebClients",
       "EnableSwagger": true
     }
   }

--- a/src/Kurio.Server/appsettings.json
+++ b/src/Kurio.Server/appsettings.json
@@ -13,7 +13,11 @@
         "http://localhost:5173",
         "http://localhost:3000"
       ],
-      "EnableSwagger": true
+      "EnableSwagger": true,
+      "Authentication": {
+        "Enabled": false,
+        "Scheme": "ApiKey"
+      }
     },
     "Storage": {
       "TempDirectory": "~/Downloads/.kurio/temp",

--- a/src/Kurio.Server/appsettings.json
+++ b/src/Kurio.Server/appsettings.json
@@ -9,10 +9,12 @@
   "AllowedHosts": "*",
   "Kurio": {
     "Server": {
+      "BaseUrl": "https://localhost:7206",
       "AllowedOrigins": [
         "http://localhost:5173",
         "http://localhost:3000"
       ],
+      "CorsPolicy": "AllowWebClients",
       "EnableSwagger": true,
       "Authentication": {
         "Enabled": false,

--- a/src/Kurio.Web/App.razor
+++ b/src/Kurio.Web/App.razor
@@ -1,0 +1,11 @@
+<Router AppAssembly="typeof(App).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="typeof(MainLayout)">
+            <p>Sorry, there is nothing here.</p>
+        </LayoutView>
+    </NotFound>
+</Router>

--- a/src/Kurio.Web/Kurio.Web.csproj
+++ b/src/Kurio.Web/Kurio.Web.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <RootNamespace>KuriousLabs.Kurio.Web</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Kurio.Contracts\Kurio.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Kurio.Web/Pages/Downloads.razor
+++ b/src/Kurio.Web/Pages/Downloads.razor
@@ -1,4 +1,395 @@
 @page "/downloads"
+@implements IAsyncDisposable
+@inject HubClientFactory HubFactory
+@inject KurioApiClient ApiClient
 
 <h1>Downloads</h1>
-<p>Planned: list of downloads with status, progress, and controls driven by Kurio.Server APIs and hubs.</p>
+
+<div class="toolbar">
+	<form class="add-form" @onsubmit="AddDownloadAsync" @onsubmit:preventDefault>
+		<input placeholder="Download URL" @bind="_newDownload.Url" required />
+		<input placeholder="File name (optional)" @bind="_newDownload.FileName" />
+		<input placeholder="Destination directory" @bind="_newDownload.DestinationDirectory" />
+		<input type="number" min="1" placeholder="Max connections" @bind="_newDownload.MaxConnections" />
+		<select @bind="_newPriority">
+			@foreach (var priority in Enum.GetValues<DownloadPriority>())
+			{
+				<option value="@priority">@priority</option>
+			}
+		</select>
+		<button type="submit" class="primary">Add</button>
+	</form>
+
+	<div class="filters">
+		<label>Filter
+			<select @bind="_filter">
+				<option value="@DownloadStateFilter.All">All</option>
+				<option value="@DownloadStateFilter.Active">Active</option>
+				<option value="@DownloadStateFilter.Completed">Completed</option>
+				<option value="@DownloadStateFilter.Failed">Failed</option>
+				<option value="@DownloadStateFilter.Paused">Paused</option>
+			</select>
+		</label>
+		<label>
+			<input type="checkbox" @bind="_includeCompleted" /> Include completed in snapshots
+		</label>
+		<button @onclick="RefreshSnapshotAsync" class="ghost">Refresh</button>
+		<button @onclick="ClearCompletedAsync" class="ghost" disabled="@(!_downloads.Any(d => d.State == DownloadState.Completed))">Clear completed</button>
+	</div>
+</div>
+
+@if (_error is not null)
+{
+	<div class="alert error">@_error</div>
+}
+else if (_connecting)
+{
+	<p class="muted">Connecting to downloads hub…</p>
+}
+else if (_downloads.Count == 0)
+{
+	<p class="muted">No downloads yet.</p>
+}
+else
+{
+	<table class="data-table">
+		<thead>
+			<tr>
+				<th>Name</th>
+				<th>Status</th>
+				<th>Progress</th>
+				<th>Speed</th>
+				<th>ETA</th>
+				<th>Priority</th>
+				<th>Created</th>
+				<th>Actions</th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var download in _downloads.OrderByDescending(d => d.Priority).ThenBy(d => d.CreatedAt))
+			{
+				<tr>
+					<td>
+						<div class="title">@download.Name</div>
+						<div class="sub">@download.Url</div>
+					</td>
+					<td><span class="badge @GetStateClass(download.State)">@download.State</span></td>
+					<td>
+						<div class="progress">
+							<div class="bar" style="width:@(download.PercentComplete?.ToString("F0") ?? "0")%"></div>
+						</div>
+						<small>@(download.PercentComplete?.ToString("F1") ?? "0")%</small>
+					</td>
+					<td>@FormatRate(download.BytesPerSecond)</td>
+					<td>@FormatEta(download.EstimatedTimeRemaining)</td>
+					<td>
+						<select value="@download.Priority" @onchange="e => ChangePriorityAsync(download.Id, Enum.Parse<DownloadPriority>(e.Value?.ToString() ?? nameof(DownloadPriority.Normal)))">
+							@foreach (var priority in Enum.GetValues<DownloadPriority>())
+							{
+								<option value="@priority" selected="@(priority == download.Priority)">@priority</option>
+							}
+						</select>
+					</td>
+					<td>@download.CreatedAt.LocalDateTime.ToString("g")</td>
+					<td class="actions">
+						@foreach (var action in GetActions(download.State))
+						{
+							<button class="ghost" @onclick="() => ExecuteActionAsync(action, download.Id)" disabled="@_actionBusy.Contains(download.Id)">@action</button>
+						}
+						<button class="danger" @onclick="() => CancelAsync(download.Id)" disabled="@_actionBusy.Contains(download.Id)">Cancel</button>
+					</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+@code {
+	private readonly HashSet<Guid> _actionBusy = new();
+	private HubConnection? _connection;
+	private bool _connecting = true;
+	private string? _error;
+	private List<DownloadSummary> _downloads = [];
+	private DownloadSubscriptionRequest _subscription = new();
+	private DownloadStateFilter _filter = DownloadStateFilter.All;
+	private bool _includeCompleted = true;
+	private CreateDownloadRequest _newDownload = new();
+	private DownloadPriority _newPriority = DownloadPriority.Normal;
+
+	protected override async Task OnInitializedAsync()
+	{
+		await ConnectAsync();
+	}
+
+	private async Task ConnectAsync()
+	{
+		_connection = HubFactory.CreateDownloadsHub();
+
+		_connection.Reconnecting += _ => OnReconnectState(ConnectionStatusKind.Reconnecting, "downloads hub reconnecting");
+		_connection.Reconnected += _ => RequestSnapshotAsync();
+		_connection.Closed += error =>
+		{
+			_error = error?.Message ?? "Connection closed";
+			_connecting = false;
+			return Task.CompletedTask;
+		};
+
+		_connection.On<IReadOnlyList<DownloadSummary>>(nameof(IDownloadsClient.ReceiveSnapshotAsync), snapshot =>
+		{
+			_downloads = snapshot.ToList();
+			_connecting = false;
+			_error = null;
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<DownloadSummary>(nameof(IDownloadsClient.DownloadUpdatedAsync), download =>
+		{
+			Upsert(download);
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<DownloadProgressUpdate>(nameof(IDownloadsClient.DownloadProgressedAsync), update =>
+		{
+			var item = _downloads.FirstOrDefault(d => d.Id == update.Id);
+			if (item is not null)
+			{
+				item = item with
+				{
+					DownloadedBytes = update.DownloadedBytes,
+					TotalBytes = update.TotalBytes,
+					PercentComplete = update.PercentComplete,
+					BytesPerSecond = update.BytesPerSecond,
+					EstimatedTimeRemaining = update.EstimatedTimeRemaining,
+					ActiveConnections = update.ActiveConnections
+				};
+				Upsert(item);
+			}
+
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<DownloadStatusChange>(nameof(IDownloadsClient.DownloadStatusChangedAsync), change =>
+		{
+			var item = _downloads.FirstOrDefault(d => d.Id == change.Id);
+			if (item is not null)
+			{
+				var updated = item with
+				{
+					State = change.CurrentState,
+					LastError = change.Failure
+				};
+				Upsert(updated);
+			}
+
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<Guid>(nameof(IDownloadsClient.DownloadRemovedAsync), id =>
+		{
+			_downloads.RemoveAll(d => d.Id == id);
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<IReadOnlyCollection<Guid>>(nameof(IDownloadsClient.DownloadsClearedAsync), ids =>
+		{
+			_downloads = _downloads.Where(d => !ids.Contains(d.Id)).ToList();
+			return InvokeAsync(StateHasChanged);
+		});
+
+		await _connection.StartAsync();
+		await RefreshSnapshotAsync();
+	}
+
+	private async Task RefreshSnapshotAsync()
+	{
+		_connecting = true;
+		_subscription = new DownloadSubscriptionRequest
+		{
+			States = _filter,
+			IncludeCompleted = _includeCompleted
+		};
+
+		if (_connection is not null)
+		{
+			await _connection.InvokeAsync(nameof(IDownloadsHub.SubscribeDownloadsAsync), _subscription);
+		}
+	}
+
+	private Task RequestSnapshotAsync()
+	{
+		_connecting = true;
+		_downloads.Clear();
+		return _connection?.InvokeAsync(nameof(IDownloadsHub.RequestSnapshotAsync)) ?? Task.CompletedTask;
+	}
+
+	private async Task AddDownloadAsync()
+	{
+		_newDownload = _newDownload with { Url = _newDownload.Url.Trim(), Priority = _newPriority };
+
+		_actionBusy.Add(Guid.Empty);
+		try
+		{
+			var request = _newDownload with { Priority = _newPriority };
+			var success = await ApiClient.AddDownloadAsync(request).ConfigureAwait(false);
+			if (!success)
+			{
+				_error = "Failed to add download";
+			}
+			else
+			{
+				_error = null;
+				_newDownload = new CreateDownloadRequest();
+			}
+		}
+		finally
+		{
+			_actionBusy.Remove(Guid.Empty);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task ExecuteActionAsync(string action, Guid id)
+	{
+		_actionBusy.Add(id);
+		try
+		{
+			var success = action switch
+			{
+				"Start" => await ApiClient.StartDownloadAsync(id).ConfigureAwait(false),
+				"Pause" => await ApiClient.PauseDownloadAsync(id).ConfigureAwait(false),
+				"Resume" => await ApiClient.ResumeDownloadAsync(id).ConfigureAwait(false),
+				_ => false
+			};
+
+			if (!success)
+			{
+				_error = $"Action {action} failed";
+			}
+		}
+		finally
+		{
+			_actionBusy.Remove(id);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task CancelAsync(Guid id)
+	{
+		_actionBusy.Add(id);
+		try
+		{
+			var success = await ApiClient.CancelDownloadAsync(id, removeFiles: false).ConfigureAwait(false);
+			if (!success)
+			{
+				_error = "Cancel failed";
+			}
+		}
+		finally
+		{
+			_actionBusy.Remove(id);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private async Task ClearCompletedAsync()
+	{
+		var success = await ApiClient.ClearCompletedAsync().ConfigureAwait(false);
+		if (!success)
+		{
+			_error = "Clear completed failed";
+		}
+	}
+
+	private async Task ChangePriorityAsync(Guid id, DownloadPriority priority)
+	{
+		_actionBusy.Add(id);
+		try
+		{
+			var success = await ApiClient.ChangeDownloadPriorityAsync(id, priority).ConfigureAwait(false);
+			if (!success)
+			{
+				_error = "Priority change failed";
+			}
+		}
+		finally
+		{
+			_actionBusy.Remove(id);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private static IEnumerable<string> GetActions(DownloadState state) => state switch
+	{
+		DownloadState.Created or DownloadState.Queued => ["Start"],
+		DownloadState.Paused or DownloadState.Failed => ["Resume"],
+		DownloadState.Downloading or DownloadState.Analyzing => ["Pause"],
+		_ => []
+	};
+
+	private static string GetStateClass(DownloadState state) => state switch
+	{
+		DownloadState.Completed => "ok",
+		DownloadState.Downloading or DownloadState.Analyzing => "warn",
+		DownloadState.Failed or DownloadState.Cancelled => "error",
+		_ => "muted"
+	};
+
+	private static string FormatRate(long? bytesPerSecond)
+	{
+		if (bytesPerSecond is null || bytesPerSecond <= 0)
+		{
+			return "-";
+		}
+
+		var rate = bytesPerSecond.Value;
+		return rate switch
+		{
+			> 1_000_000 => $"{rate / 1_000_000d:F1} MB/s",
+			> 1_000 => $"{rate / 1_000d:F1} KB/s",
+			_ => $"{rate} B/s"
+		};
+	}
+
+	private static string FormatEta(TimeSpan? eta)
+	{
+		if (eta is null)
+		{
+			return "-";
+		}
+
+		if (eta.Value.TotalHours >= 1)
+		{
+			return $"{eta:hh\\:mm\\:ss}";
+		}
+
+		return $"{eta:mm\\:ss}";
+	}
+
+	private void Upsert(DownloadSummary download)
+	{
+		var existingIndex = _downloads.FindIndex(d => d.Id == download.Id);
+		if (existingIndex >= 0)
+		{
+			_downloads[existingIndex] = download;
+		}
+		else
+		{
+			_downloads.Add(download);
+		}
+	}
+
+	private Task OnReconnectState(ConnectionStatusKind status, string message)
+	{
+		_connecting = status is ConnectionStatusKind.Connecting or ConnectionStatusKind.Reconnecting;
+		_error = message;
+		return InvokeAsync(StateHasChanged);
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_connection is not null)
+		{
+			await _connection.DisposeAsync();
+		}
+	}
+}

--- a/src/Kurio.Web/Pages/Downloads.razor
+++ b/src/Kurio.Web/Pages/Downloads.razor
@@ -1,0 +1,4 @@
+@page "/downloads"
+
+<h1>Downloads</h1>
+<p>Planned: list of downloads with status, progress, and controls driven by Kurio.Server APIs and hubs.</p>

--- a/src/Kurio.Web/Pages/Error.cshtml
+++ b/src/Kurio.Web/Pages/Error.cshtml
@@ -1,0 +1,8 @@
+@page
+@model KuriousLabs.Kurio.Web.Pages.ErrorModel
+@{
+    Layout = "_Layout";
+}
+
+<h1>Sorry, something went wrong.</h1>
+<p>Please try again later.</p>

--- a/src/Kurio.Web/Pages/Error.cshtml.cs
+++ b/src/Kurio.Web/Pages/Error.cshtml.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace KuriousLabs.Kurio.Web.Pages;
+
+public sealed class ErrorModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/src/Kurio.Web/Pages/Index.razor
+++ b/src/Kurio.Web/Pages/Index.razor
@@ -1,11 +1,11 @@
 @page "/"
+@inject NavigationManager Navigation
 
-<h1>Dashboard Host Ready</h1>
+<p class="muted">Redirecting to overview…</p>
 
-<p>This host is wired to Kurio.Server via contracts, HTTP, and SignalR. Upcoming pages will surface downloads, queue, and stats.</p>
-
-<ul>
-    <li>Server base URL and hubs are configurable via <code>appsettings.json</code>.</li>
-    <li>Only contracts are referenced; engine dependencies stay on the server side.</li>
-    <li>SignalR connections are created via <code>HubClientFactory</code> with automatic reconnect.</li>
-</ul>
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateTo("/overview", true);
+    }
+}

--- a/src/Kurio.Web/Pages/Index.razor
+++ b/src/Kurio.Web/Pages/Index.razor
@@ -1,0 +1,11 @@
+@page "/"
+
+<h1>Dashboard Host Ready</h1>
+
+<p>This host is wired to Kurio.Server via contracts, HTTP, and SignalR. Upcoming pages will surface downloads, queue, and stats.</p>
+
+<ul>
+    <li>Server base URL and hubs are configurable via <code>appsettings.json</code>.</li>
+    <li>Only contracts are referenced; engine dependencies stay on the server side.</li>
+    <li>SignalR connections are created via <code>HubClientFactory</code> with automatic reconnect.</li>
+</ul>

--- a/src/Kurio.Web/Pages/Overview.razor
+++ b/src/Kurio.Web/Pages/Overview.razor
@@ -1,0 +1,4 @@
+@page "/overview"
+
+<h1>Overview</h1>
+<p>This page will summarize active downloads, throughput, and health. Data will be populated from Kurio.Server contracts and hubs.</p>

--- a/src/Kurio.Web/Pages/Overview.razor
+++ b/src/Kurio.Web/Pages/Overview.razor
@@ -1,4 +1,198 @@
 @page "/overview"
+@implements IAsyncDisposable
+@inject HubClientFactory HubFactory
 
 <h1>Overview</h1>
-<p>This page will summarize active downloads, throughput, and health. Data will be populated from Kurio.Server contracts and hubs.</p>
+
+<div class="grid">
+	<div class="card">
+		<div class="label">Active</div>
+		<div class="value">@(_stats?.ActiveCount ?? 0)</div>
+	</div>
+	<div class="card">
+		<div class="label">Queued</div>
+		<div class="value">@(_stats?.QueuedCount ?? 0)</div>
+	</div>
+	<div class="card">
+		<div class="label">Completed</div>
+		<div class="value">@(_stats?.CompletedCount ?? 0)</div>
+	</div>
+	<div class="card">
+		<div class="label">Failed</div>
+		<div class="value">@(_stats?.FailedCount ?? 0)</div>
+	</div>
+	<div class="card">
+		<div class="label">Throughput</div>
+		<div class="value">@FormatRate(_stats?.CurrentThroughputBytesPerSecond)</div>
+	</div>
+	<div class="card">
+		<div class="label">Average</div>
+		<div class="value">@FormatRate(_stats?.AverageThroughputBytesPerSecond)</div>
+	</div>
+</div>
+
+<section>
+	<header class="section-header">
+		<h2>Active Downloads</h2>
+		<NavLink class="ghost" href="/downloads">View all</NavLink>
+	</header>
+	@if (_downloads.Count == 0)
+	{
+		<p class="muted">No active downloads.</p>
+	}
+	else
+	{
+		<ul class="download-list">
+			@foreach (var download in _downloads.OrderByDescending(d => d.Priority).ThenBy(d => d.CreatedAt).Take(5))
+			{
+				<li>
+					<div class="title">@download.Name</div>
+					<div class="sub">@download.Url</div>
+					<div class="meta">
+						<span class="badge @GetStateClass(download.State)">@download.State</span>
+						<span>@(download.PercentComplete?.ToString("F1") ?? "0")%</span>
+						<span>@FormatRate(download.BytesPerSecond)</span>
+						<span>@FormatEta(download.EstimatedTimeRemaining)</span>
+					</div>
+					<div class="progress small">
+						<div class="bar" style="width:@(download.PercentComplete?.ToString("F0") ?? "0")%"></div>
+					</div>
+				</li>
+			}
+		</ul>
+	}
+</section>
+
+@code {
+	private HubConnection? _statsConnection;
+	private HubConnection? _downloadsConnection;
+	private StatsSnapshot? _stats;
+	private List<DownloadSummary> _downloads = [];
+
+	protected override async Task OnInitializedAsync()
+	{
+		await ConnectStatsAsync();
+		await ConnectDownloadsAsync();
+	}
+
+	private async Task ConnectStatsAsync()
+	{
+		_statsConnection = HubFactory.CreateStatsHub();
+		_statsConnection.On<StatsSnapshot>(nameof(IStatsClient.StatsSnapshotAsync), snapshot =>
+		{
+			_stats = snapshot;
+			return InvokeAsync(StateHasChanged);
+		});
+		_statsConnection.On<StatsSnapshot>(nameof(IStatsClient.StatsUpdatedAsync), snapshot =>
+		{
+			_stats = snapshot;
+			return InvokeAsync(StateHasChanged);
+		});
+		await _statsConnection.StartAsync();
+		await _statsConnection.InvokeAsync(nameof(IStatsHub.SubscribeStatsAsync));
+	}
+
+	private async Task ConnectDownloadsAsync()
+	{
+		_downloadsConnection = HubFactory.CreateDownloadsHub();
+		_downloadsConnection.On<IReadOnlyList<DownloadSummary>>(nameof(IDownloadsClient.ReceiveSnapshotAsync), snapshot =>
+		{
+			_downloads = snapshot.ToList();
+			return InvokeAsync(StateHasChanged);
+		});
+		_downloadsConnection.On<DownloadSummary>(nameof(IDownloadsClient.DownloadUpdatedAsync), download =>
+		{
+			Upsert(download);
+			return InvokeAsync(StateHasChanged);
+		});
+		_downloadsConnection.On<DownloadProgressUpdate>(nameof(IDownloadsClient.DownloadProgressedAsync), progress =>
+		{
+			var item = _downloads.FirstOrDefault(d => d.Id == progress.Id);
+			if (item is not null)
+			{
+				Upsert(item with
+				{
+					DownloadedBytes = progress.DownloadedBytes,
+					TotalBytes = progress.TotalBytes,
+					PercentComplete = progress.PercentComplete,
+					BytesPerSecond = progress.BytesPerSecond,
+					EstimatedTimeRemaining = progress.EstimatedTimeRemaining,
+					ActiveConnections = progress.ActiveConnections
+				});
+			}
+			return InvokeAsync(StateHasChanged);
+		});
+
+		await _downloadsConnection.StartAsync();
+		await _downloadsConnection.InvokeAsync(nameof(IDownloadsHub.SubscribeDownloadsAsync), new DownloadSubscriptionRequest
+		{
+			States = DownloadStateFilter.Active,
+			IncludeCompleted = false,
+			Limit = 10
+		});
+	}
+
+	private static string GetStateClass(DownloadState state) => state switch
+	{
+		DownloadState.Completed => "ok",
+		DownloadState.Downloading or DownloadState.Analyzing => "warn",
+		DownloadState.Failed or DownloadState.Cancelled => "error",
+		_ => "muted"
+	};
+
+	private void Upsert(DownloadSummary download)
+	{
+		var index = _downloads.FindIndex(d => d.Id == download.Id);
+		if (index >= 0)
+		{
+			_downloads[index] = download;
+		}
+		else
+		{
+			_downloads.Add(download);
+		}
+	}
+
+	private static string FormatRate(long? bytesPerSecond)
+	{
+		if (bytesPerSecond is null || bytesPerSecond <= 0)
+		{
+			return "-";
+		}
+
+		return bytesPerSecond.Value switch
+		{
+			> 1_000_000 => $"{bytesPerSecond.Value / 1_000_000d:F1} MB/s",
+			> 1_000 => $"{bytesPerSecond.Value / 1_000d:F1} KB/s",
+			_ => $"{bytesPerSecond} B/s"
+		};
+	}
+
+	private static string FormatEta(TimeSpan? eta)
+	{
+		if (eta is null)
+		{
+			return "-";
+		}
+
+		if (eta.Value.TotalHours >= 1)
+		{
+			return $"{eta:hh\\:mm\\:ss}";
+		}
+
+		return $"{eta:mm\\:ss}";
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_statsConnection is not null)
+		{
+			await _statsConnection.DisposeAsync();
+		}
+
+		if (_downloadsConnection is not null)
+		{
+			await _downloadsConnection.DisposeAsync();
+		}
+	}
+}

--- a/src/Kurio.Web/Pages/Queue.razor
+++ b/src/Kurio.Web/Pages/Queue.razor
@@ -1,4 +1,212 @@
 @page "/queue"
+@implements IAsyncDisposable
+@inject HubClientFactory HubFactory
+@inject KurioApiClient ApiClient
 
 <h1>Queue</h1>
-<p>Planned: queue management view with prioritization and reordering backed by SignalR updates.</p>
+
+<div class="toolbar">
+	<button class="ghost" @onclick="RefreshSnapshotAsync">Refresh</button>
+</div>
+
+@if (_error is not null)
+{
+	<div class="alert error">@_error</div>
+}
+else if (_connecting)
+{
+	<p class="muted">Connecting to queue hub…</p>
+}
+else if (_items.Count == 0)
+{
+	<p class="muted">Queue is empty.</p>
+}
+else
+{
+	<table class="data-table">
+		<thead>
+			<tr>
+				<th>Position</th>
+				<th>Name</th>
+				<th>Category</th>
+				<th>Priority</th>
+				<th>Added</th>
+				<th>Actions</th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var item in _items.OrderBy(i => i.Position))
+			{
+				<tr>
+					<td>@item.Position</td>
+					<td>@item.Name</td>
+					<td>@(item.Category ?? "-")</td>
+					<td>
+						<select value="@item.Priority" @onchange="e => ChangePriorityAsync(item.DownloadId, Enum.Parse<DownloadPriority>(e.Value?.ToString() ?? nameof(DownloadPriority.Normal)))">
+							@foreach (var priority in Enum.GetValues<DownloadPriority>())
+							{
+								<option value="@priority" selected="@(priority == item.Priority)">@priority</option>
+							}
+						</select>
+					</td>
+					<td>@item.AddedAt.LocalDateTime.ToString("g")</td>
+					<td class="actions">
+						<button class="ghost" @onclick="() => MoveUp(item.DownloadId)" disabled="@_busy.Contains(item.DownloadId)">Up</button>
+						<button class="ghost" @onclick="() => MoveDown(item.DownloadId)" disabled="@_busy.Contains(item.DownloadId)">Down</button>
+						<button class="ghost" @onclick="() => MoveTop(item.DownloadId)" disabled="@_busy.Contains(item.DownloadId)">Top</button>
+						<button class="ghost" @onclick="() => MoveBottom(item.DownloadId)" disabled="@_busy.Contains(item.DownloadId)">Bottom</button>
+					</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}
+
+@code {
+	private HubConnection? _connection;
+	private List<QueueItem> _items = [];
+	private string? _error;
+	private bool _connecting = true;
+	private readonly HashSet<Guid> _busy = new();
+
+	protected override async Task OnInitializedAsync()
+	{
+		await ConnectAsync();
+	}
+
+	private async Task ConnectAsync()
+	{
+		_connection = HubFactory.CreateQueueHub();
+
+		_connection.Reconnecting += _ => OnReconnect("Queue hub reconnecting");
+		_connection.Reconnected += _ => RequestSnapshotAsync();
+		_connection.Closed += error =>
+		{
+			_error = error?.Message ?? "Connection closed";
+			_connecting = false;
+			return Task.CompletedTask;
+		};
+
+		_connection.On<IReadOnlyList<QueueItem>>(nameof(IQueueClient.QueueSnapshotAsync), snapshot =>
+		{
+			_items = snapshot.OrderBy(i => i.Position).ToList();
+			_connecting = false;
+			_error = null;
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<QueueItem>(nameof(IQueueClient.QueueItemEnqueuedAsync), item =>
+		{
+			Upsert(item);
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<Guid>(nameof(IQueueClient.QueueItemRemovedAsync), id =>
+		{
+			_items.RemoveAll(i => i.DownloadId == id);
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<QueuePositionChanged>(nameof(IQueueClient.QueuePositionChangedAsync), change =>
+		{
+			var item = _items.FirstOrDefault(i => i.DownloadId == change.DownloadId);
+			if (item is not null)
+			{
+				Upsert(item with { Position = change.Position, Priority = change.Priority });
+			}
+
+			return InvokeAsync(StateHasChanged);
+		});
+
+		await _connection.StartAsync();
+		await RefreshSnapshotAsync();
+	}
+
+	private async Task RefreshSnapshotAsync()
+	{
+		_connecting = true;
+		if (_connection is not null)
+		{
+			await _connection.InvokeAsync(nameof(IQueueHub.SubscribeQueueAsync));
+		}
+	}
+
+	private Task RequestSnapshotAsync()
+	{
+		_connecting = true;
+		_items.Clear();
+		return _connection?.InvokeAsync(nameof(IQueueHub.RequestQueueSnapshotAsync)) ?? Task.CompletedTask;
+	}
+
+	private async Task MoveAsync(Guid id, string action)
+	{
+		_busy.Add(id);
+		try
+		{
+			var success = await ApiClient.MoveQueueAsync(id, action).ConfigureAwait(false);
+			if (!success)
+			{
+				_error = "Queue move failed";
+			}
+		}
+		finally
+		{
+			_busy.Remove(id);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private Task MoveUp(Guid id) => MoveAsync(id, "move-up");
+
+	private Task MoveDown(Guid id) => MoveAsync(id, "move-down");
+
+	private Task MoveTop(Guid id) => MoveAsync(id, "move-top");
+
+	private Task MoveBottom(Guid id) => MoveAsync(id, "move-bottom");
+
+	private async Task ChangePriorityAsync(Guid id, DownloadPriority priority)
+	{
+		_busy.Add(id);
+		try
+		{
+			var success = await ApiClient.ChangeQueuePriorityAsync(id, priority).ConfigureAwait(false);
+			if (!success)
+			{
+				_error = "Priority change failed";
+			}
+		}
+		finally
+		{
+			_busy.Remove(id);
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private Task OnReconnect(string message)
+	{
+		_connecting = true;
+		_error = message;
+		return InvokeAsync(StateHasChanged);
+	}
+
+	private void Upsert(QueueItem item)
+	{
+		var index = _items.FindIndex(i => i.DownloadId == item.DownloadId);
+		if (index >= 0)
+		{
+			_items[index] = item;
+		}
+		else
+		{
+			_items.Add(item);
+		}
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_connection is not null)
+		{
+			await _connection.DisposeAsync();
+		}
+	}
+}

--- a/src/Kurio.Web/Pages/Queue.razor
+++ b/src/Kurio.Web/Pages/Queue.razor
@@ -1,0 +1,4 @@
+@page "/queue"
+
+<h1>Queue</h1>
+<p>Planned: queue management view with prioritization and reordering backed by SignalR updates.</p>

--- a/src/Kurio.Web/Pages/Settings.razor
+++ b/src/Kurio.Web/Pages/Settings.razor
@@ -1,4 +1,98 @@
 @page "/settings"
+@inject KurioApiClient ApiClient
 
 <h1>Settings</h1>
-<p>Planned: configuration surface for server endpoints, categories, and preferences (auth to be defined in #73).</p>
+
+@if (_error is not null)
+{
+	<div class="alert error">@_error</div>
+}
+
+@if (_speedLimit is null)
+{
+	<p class="muted">Loading speed limit…</p>
+}
+else
+{
+	<form class="stack" @onsubmit="UpdateAsync" @onsubmit:preventDefault>
+		<label>
+			<input type="checkbox" @bind="_speedLimit.Enabled" /> Enable speed limit
+		</label>
+		<label>
+			Max download (B/s)
+			<input type="number" min="0" @bind="_speedLimit.MaxDownloadSpeedBytesPerSecond" />
+		</label>
+		<label>
+			Max upload (B/s)
+			<input type="number" min="0" @bind="_speedLimit.MaxUploadSpeedBytesPerSecond" />
+		</label>
+		<p class="muted">Current limit: @(_speedLimit.CurrentLimitBytesPerSecond == 0 ? "Unlimited" : FormatRate(_speedLimit.CurrentLimitBytesPerSecond))</p>
+		<button type="submit" class="primary" disabled="@_busy">Save</button>
+	</form>
+}
+
+@code {
+	private SpeedLimitResponseModel? _speedLimit;
+	private string? _error;
+	private bool _busy;
+
+	protected override async Task OnInitializedAsync()
+	{
+		await LoadAsync();
+	}
+
+	private async Task LoadAsync()
+	{
+		_speedLimit = await ApiClient.GetSpeedLimitAsync().ConfigureAwait(false);
+		await InvokeAsync(StateHasChanged);
+	}
+
+	private async Task UpdateAsync()
+	{
+		if (_speedLimit is null)
+		{
+			return;
+		}
+
+		_busy = true;
+		_error = null;
+		try
+		{
+			var success = await ApiClient.UpdateSpeedLimitAsync(new UpdateSpeedLimitRequestModel
+			{
+				Enabled = _speedLimit.Enabled,
+				MaxDownloadSpeedBytesPerSecond = _speedLimit.MaxDownloadSpeedBytesPerSecond,
+				MaxUploadSpeedBytesPerSecond = _speedLimit.MaxUploadSpeedBytesPerSecond
+			}).ConfigureAwait(false);
+
+			if (!success)
+			{
+				_error = "Failed to update speed limit";
+			}
+			else
+			{
+				_speedLimit = await ApiClient.GetSpeedLimitAsync().ConfigureAwait(false);
+			}
+		}
+		finally
+		{
+			_busy = false;
+			await InvokeAsync(StateHasChanged);
+		}
+	}
+
+	private static string FormatRate(long bytesPerSecond)
+	{
+		if (bytesPerSecond <= 0)
+		{
+			return "Unlimited";
+		}
+
+		return bytesPerSecond switch
+		{
+			> 1_000_000 => $"{bytesPerSecond / 1_000_000d:F1} MB/s",
+			> 1_000 => $"{bytesPerSecond / 1_000d:F1} KB/s",
+			_ => $"{bytesPerSecond} B/s"
+		};
+	}
+}

--- a/src/Kurio.Web/Pages/Settings.razor
+++ b/src/Kurio.Web/Pages/Settings.razor
@@ -1,0 +1,4 @@
+@page "/settings"
+
+<h1>Settings</h1>
+<p>Planned: configuration surface for server endpoints, categories, and preferences (auth to be defined in #73).</p>

--- a/src/Kurio.Web/Pages/Shared/_Layout.cshtml
+++ b/src/Kurio.Web/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kurio Dashboard</title>
+    <link rel="stylesheet" href="/css/app.css" />
+</head>
+<body>
+    <div class="main">
+        @RenderBody()
+    </div>
+</body>
+</html>

--- a/src/Kurio.Web/Pages/Stats.razor
+++ b/src/Kurio.Web/Pages/Stats.razor
@@ -1,4 +1,142 @@
 @page "/stats"
+@implements IAsyncDisposable
+@inject HubClientFactory HubFactory
 
 <h1>Statistics</h1>
-<p>Planned: live throughput, history, and session metrics streamed from Kurio.Server hubs.</p>
+
+@if (_error is not null)
+{
+	<div class="alert error">@_error</div>
+}
+else if (_snapshot is null)
+{
+	<p class="muted">Waiting for stats…</p>
+}
+else
+{
+	<div class="grid">
+		<div class="card">
+			<div class="label">Active</div>
+			<div class="value">@_snapshot.ActiveCount</div>
+		</div>
+		<div class="card">
+			<div class="label">Queued</div>
+			<div class="value">@_snapshot.QueuedCount</div>
+		</div>
+		<div class="card">
+			<div class="label">Completed</div>
+			<div class="value">@_snapshot.CompletedCount</div>
+		</div>
+		<div class="card">
+			<div class="label">Failed</div>
+			<div class="value">@_snapshot.FailedCount</div>
+		</div>
+		<div class="card">
+			<div class="label">Throughput (now)</div>
+			<div class="value">@FormatRate(_snapshot.CurrentThroughputBytesPerSecond)</div>
+		</div>
+		<div class="card">
+			<div class="label">Throughput (avg)</div>
+			<div class="value">@FormatRate(_snapshot.AverageThroughputBytesPerSecond)</div>
+		</div>
+		<div class="card">
+			<div class="label">Total bytes</div>
+			<div class="value">@FormatBytes(_snapshot.TotalBytesDownloaded)</div>
+		</div>
+		<div class="card">
+			<div class="label">Started</div>
+			<div class="value">@(_snapshot.StartedAt?.LocalDateTime.ToString("g") ?? "-" )</div>
+		</div>
+	</div>
+}
+
+@code {
+	private HubConnection? _connection;
+	private StatsSnapshot? _snapshot;
+	private string? _error;
+
+	protected override async Task OnInitializedAsync()
+	{
+		await ConnectAsync();
+	}
+
+	private async Task ConnectAsync()
+	{
+		_connection = HubFactory.CreateStatsHub();
+
+		_connection.Reconnected += _ => RequestSnapshotAsync();
+		_connection.Reconnecting += _ => OnReconnect("Stats hub reconnecting");
+		_connection.Closed += error =>
+		{
+			_error = error?.Message ?? "Connection closed";
+			return Task.CompletedTask;
+		};
+
+		_connection.On<StatsSnapshot>(nameof(IStatsClient.StatsSnapshotAsync), snapshot =>
+		{
+			_snapshot = snapshot;
+			_error = null;
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<StatsSnapshot>(nameof(IStatsClient.StatsUpdatedAsync), snapshot =>
+		{
+			_snapshot = snapshot;
+			return InvokeAsync(StateHasChanged);
+		});
+
+		_connection.On<Alert>(nameof(IStatsClient.AlertRaisedAsync), alert =>
+		{
+			_error = alert.Message;
+			return InvokeAsync(StateHasChanged);
+		});
+
+		await _connection.StartAsync();
+		await RequestSnapshotAsync();
+	}
+
+	private Task RequestSnapshotAsync()
+	{
+		return _connection?.InvokeAsync(nameof(IStatsHub.SubscribeStatsAsync)) ?? Task.CompletedTask;
+	}
+
+	private Task OnReconnect(string message)
+	{
+		_error = message;
+		return InvokeAsync(StateHasChanged);
+	}
+
+	private static string FormatRate(long bytesPerSecond)
+	{
+		if (bytesPerSecond <= 0)
+		{
+			return "-";
+		}
+
+		return bytesPerSecond switch
+		{
+			> 1_000_000 => $"{bytesPerSecond / 1_000_000d:F1} MB/s",
+			> 1_000 => $"{bytesPerSecond / 1_000d:F1} KB/s",
+			_ => $"{bytesPerSecond} B/s"
+		};
+	}
+
+	private static string FormatBytes(long value)
+	{
+		return value switch
+		{
+			> 1_000_000_000 => $"{value / 1_000_000_000d:F1} GB",
+			> 1_000_000 => $"{value / 1_000_000d:F1} MB",
+			> 1_000 => $"{value / 1_000d:F1} KB",
+			_ => $"{value} B"
+		};
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_connection is not null)
+		{
+			await _connection.DisposeAsync();
+		}
+	}
+}

--- a/src/Kurio.Web/Pages/Stats.razor
+++ b/src/Kurio.Web/Pages/Stats.razor
@@ -1,0 +1,4 @@
+@page "/stats"
+
+<h1>Statistics</h1>
+<p>Planned: live throughput, history, and session metrics streamed from Kurio.Server hubs.</p>

--- a/src/Kurio.Web/Pages/_Host.cshtml
+++ b/src/Kurio.Web/Pages/_Host.cshtml
@@ -1,0 +1,23 @@
+@page "/"
+@namespace KuriousLabs.Kurio.Web.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@using Microsoft.AspNetCore.Components.Web
+@{
+    Layout = "_Layout";
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="~" />
+    <link rel="stylesheet" href="css/app.css" />
+    <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+</head>
+<body>
+    <component type="typeof(App)" render-mode="ServerPrerendered" />
+
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/src/Kurio.Web/Pages/_Imports.razor
+++ b/src/Kurio.Web/Pages/_Imports.razor
@@ -1,0 +1,7 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Routing
+@using KuriousLabs.Kurio.Contracts
+@using KuriousLabs.Kurio.Web
+@using KuriousLabs.Kurio.Web.Services

--- a/src/Kurio.Web/Program.cs
+++ b/src/Kurio.Web/Program.cs
@@ -12,6 +12,21 @@ builder.Services.AddOptions<KurioServerOptions>()
     .ValidateOnStart();
 builder.Services.AddSingleton<IValidateOptions<KurioServerOptions>, KurioServerOptionsValidator>();
 
+// Authentication (optional, disabled by default for local dev)
+var authEnabled = builder.Configuration.GetValue<bool>("Authentication:Enabled");
+if (authEnabled)
+{
+    builder.Services.AddAuthentication("Cookies")
+        .AddCookie("Cookies", options =>
+        {
+            options.LoginPath = "/login";
+            options.LogoutPath = "/logout";
+            options.ExpireTimeSpan = TimeSpan.FromHours(24);
+            options.SlidingExpiration = true;
+        });
+    builder.Services.AddAuthorization();
+}
+
 // Services
 builder.Services.AddResponseCompression(options =>
 {
@@ -26,6 +41,12 @@ builder.Services.AddHttpClient<KurioApiClient>((sp, client) =>
     var options = sp.GetRequiredService<IOptionsMonitor<KurioServerOptions>>().CurrentValue;
     client.BaseAddress = options.BaseUrl;
     client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+    
+    // Add API key if authentication is enabled
+    if (options.Authentication?.Enabled == true && !string.IsNullOrEmpty(options.Authentication.ApiKey))
+    {
+        client.DefaultRequestHeaders.Add("X-Api-Key", options.Authentication.ApiKey);
+    }
 }).AddStandardResilienceHandler();
 
 builder.Services.AddSingleton<HubClientFactory>();
@@ -43,6 +64,13 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
+
+if (authEnabled)
+{
+    app.UseAuthentication();
+    app.UseAuthorization();
+}
+
 app.UseResponseCompression();
 
 app.MapBlazorHub();

--- a/src/Kurio.Web/Program.cs
+++ b/src/Kurio.Web/Program.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using KuriousLabs.Kurio.Web.Services;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Options;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Options
+builder.Services.AddOptions<KurioServerOptions>()
+    .Bind(builder.Configuration.GetSection("KurioServer"))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<KurioServerOptions>, KurioServerOptionsValidator>();
+
+// Services
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(["application/octet-stream"]);
+});
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+
+builder.Services.AddHttpClient<KurioApiClient>((sp, client) =>
+{
+    var options = sp.GetRequiredService<IOptionsMonitor<KurioServerOptions>>().CurrentValue;
+    client.BaseAddress = options.BaseUrl;
+    client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+}).AddStandardResilienceHandler();
+
+builder.Services.AddSingleton<HubClientFactory>();
+builder.Services.AddSingleton<ConnectionStateService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<ConnectionStateService>());
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseRouting();
+app.UseResponseCompression();
+
+app.MapBlazorHub();
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/src/Kurio.Web/Properties/launchSettings.json
+++ b/src/Kurio.Web/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "Kurio.Web": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7211;http://localhost:5211",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/Kurio.Web/Services/ConnectionStateService.cs
+++ b/src/Kurio.Web/Services/ConnectionStateService.cs
@@ -1,0 +1,110 @@
+using System.Threading;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace KuriousLabs.Kurio.Web.Services;
+
+public enum ConnectionStatusKind
+{
+    Unknown,
+    Connecting,
+    Connected,
+    Reconnecting,
+    Disconnected,
+    Error
+}
+
+public sealed record ConnectionStatusSnapshot(ConnectionStatusKind Status, DateTimeOffset UpdatedAtUtc, string? Message = null);
+
+/// <summary>
+/// Background health monitor that pings the API and exposes the latest connection snapshot.
+/// </summary>
+public sealed class ConnectionStateService : BackgroundService
+{
+    private static readonly TimeSpan ProbeInterval = TimeSpan.FromSeconds(30);
+
+    private readonly KurioApiClient _apiClient;
+    private readonly ILogger<ConnectionStateService> _logger;
+    private readonly PeriodicTimer _timer = new(ProbeInterval);
+
+    private int _isProbing;
+    private ConnectionStatusSnapshot _snapshot = new(ConnectionStatusKind.Unknown, DateTimeOffset.UtcNow, "Not started");
+
+    public ConnectionStateService(KurioApiClient apiClient, ILogger<ConnectionStateService> logger)
+    {
+        _apiClient = apiClient;
+        _logger = logger;
+    }
+
+    public ConnectionStatusSnapshot Current => _snapshot;
+
+    public event Action<ConnectionStatusSnapshot>? Changed;
+
+    public Task TriggerProbeAsync(CancellationToken cancellationToken = default) => ProbeAsync(true, cancellationToken);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await ProbeAsync(immediate: true, stoppingToken).ConfigureAwait(false);
+
+        while (await _timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false))
+        {
+            await ProbeAsync(immediate: false, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ProbeAsync(bool immediate, CancellationToken cancellationToken)
+    {
+        if (Interlocked.Exchange(ref _isProbing, 1) == 1)
+        {
+            return;
+        }
+
+        try
+        {
+            if (immediate)
+            {
+                UpdateSnapshot(new(ConnectionStatusKind.Connecting, DateTimeOffset.UtcNow));
+            }
+
+            var healthy = await _apiClient.CheckHealthAsync(cancellationToken).ConfigureAwait(false);
+            if (healthy)
+            {
+                UpdateSnapshot(new(ConnectionStatusKind.Connected, DateTimeOffset.UtcNow));
+                return;
+            }
+
+            UpdateSnapshot(new(ConnectionStatusKind.Error, DateTimeOffset.UtcNow, "Health check failed"));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogConnectionProbeFailed(ex);
+            UpdateSnapshot(new(ConnectionStatusKind.Error, DateTimeOffset.UtcNow, ex.Message));
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _isProbing, 0);
+        }
+    }
+
+    private void UpdateSnapshot(ConnectionStatusSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+        Changed?.Invoke(snapshot);
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer.Dispose();
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+
+internal static partial class ConnectionStateLogging
+{
+    [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "Connection probe failed")]
+    public static partial void LogConnectionProbeFailed(this ILogger logger, Exception exception);
+}

--- a/src/Kurio.Web/Services/HubClientFactory.cs
+++ b/src/Kurio.Web/Services/HubClientFactory.cs
@@ -31,7 +31,12 @@ public sealed class HubClientFactory
         var connection = new HubConnectionBuilder()
             .WithUrl(hubUri, options =>
             {
-                // Placeholder for auth headers/token once #73 is defined.
+                // Add API key header if authentication is enabled
+                var auth = _options.CurrentValue.Authentication;
+                if (auth?.Enabled == true && !string.IsNullOrEmpty(auth.ApiKey))
+                {
+                    options.Headers.Add("X-Api-Key", auth.ApiKey);
+                }
             })
             .WithAutomaticReconnect(new[]
             {

--- a/src/Kurio.Web/Services/HubClientFactory.cs
+++ b/src/Kurio.Web/Services/HubClientFactory.cs
@@ -1,0 +1,80 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace KuriousLabs.Kurio.Web.Services;
+
+public sealed class HubClientFactory
+{
+    private readonly IOptionsMonitor<KurioServerOptions> _options;
+    private readonly ILogger<HubClientFactory> _logger;
+
+    public HubClientFactory(IOptionsMonitor<KurioServerOptions> options, ILogger<HubClientFactory> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public HubConnection CreateDownloadsHub() => CreateHub(_options.CurrentValue.Hubs.Downloads);
+
+    public HubConnection CreateQueueHub() => CreateHub(_options.CurrentValue.Hubs.Queue);
+
+    public HubConnection CreateStatsHub() => CreateHub(_options.CurrentValue.Hubs.Stats);
+
+    private HubConnection CreateHub(string relativePath)
+    {
+        var baseUri = _options.CurrentValue.BaseUrl;
+        var hubUri = new Uri(baseUri, relativePath);
+
+        _logger.LogCreatingHub(hubUri);
+
+        var connection = new HubConnectionBuilder()
+            .WithUrl(hubUri, options =>
+            {
+                // Placeholder for auth headers/token once #73 is defined.
+            })
+            .WithAutomaticReconnect(new[]
+            {
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromSeconds(30)
+            })
+            .Build();
+
+        connection.Reconnecting += error =>
+        {
+            _logger.LogHubReconnecting(hubUri, error?.Message ?? "reconnecting");
+            return Task.CompletedTask;
+        };
+
+        connection.Reconnected += connectionId =>
+        {
+            _logger.LogHubReconnected(hubUri, connectionId ?? "(none)");
+            return Task.CompletedTask;
+        };
+
+        connection.Closed += error =>
+        {
+            _logger.LogHubClosed(hubUri, error?.Message ?? "closed");
+            return Task.CompletedTask;
+        };
+
+        return connection;
+    }
+}
+
+internal static partial class HubClientFactoryLogging
+{
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Creating hub connection to {HubUri}")]
+    public static partial void LogCreatingHub(this ILogger logger, Uri hubUri);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Warning, Message = "Hub reconnecting {HubUri}: {Reason}")]
+    public static partial void LogHubReconnecting(this ILogger logger, Uri hubUri, string reason);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "Hub reconnected {HubUri} with connection id {ConnectionId}")]
+    public static partial void LogHubReconnected(this ILogger logger, Uri hubUri, string connectionId);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Hub closed {HubUri}: {Reason}")]
+    public static partial void LogHubClosed(this ILogger logger, Uri hubUri, string reason);
+}

--- a/src/Kurio.Web/Services/KurioApiClient.cs
+++ b/src/Kurio.Web/Services/KurioApiClient.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging;
+
+namespace KuriousLabs.Kurio.Web.Services;
+
+public sealed class KurioApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<KurioApiClient> _logger;
+
+    public KurioApiClient(HttpClient httpClient, ILogger<KurioApiClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var response = await _httpClient.GetAsync("/health", cancellationToken).ConfigureAwait(false);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogHealthCheckFailed(ex);
+            return false;
+        }
+    }
+}
+
+internal static partial class KurioApiClientLogging
+{
+    [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Health check failed")]
+    public static partial void LogHealthCheckFailed(this ILogger logger, Exception exception);
+}

--- a/src/Kurio.Web/Services/KurioApiClient.cs
+++ b/src/Kurio.Web/Services/KurioApiClient.cs
@@ -1,3 +1,9 @@
+using System.Net.Http.Json;
+
+using KuriousLabs.Kurio.Contracts.Downloads;
+using KuriousLabs.Kurio.Contracts.Queue;
+using KuriousLabs.Kurio.Contracts.Stats;
+
 using Microsoft.Extensions.Logging;
 
 namespace KuriousLabs.Kurio.Web.Services;
@@ -13,6 +19,71 @@ public sealed class KurioApiClient
         _logger = logger;
     }
 
+    public async Task<bool> AddDownloadAsync(CreateDownloadRequest request, CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.PostAsJsonAsync("api/downloads", request, cancellationToken)
+            .ConfigureAwait(false);
+        return response.IsSuccessStatusCode;
+    }
+
+    public Task<bool> StartDownloadAsync(Guid id, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, $"api/downloads/{id}/start", null, cancellationToken);
+
+    public Task<bool> PauseDownloadAsync(Guid id, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, $"api/downloads/{id}/pause", null, cancellationToken);
+
+    public Task<bool> ResumeDownloadAsync(Guid id, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, $"api/downloads/{id}/resume", null, cancellationToken);
+
+    public Task<bool> CancelDownloadAsync(Guid id, bool removeFiles, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Delete, $"api/downloads/{id}?removeFiles={removeFiles}", null, cancellationToken);
+
+    public Task<bool> ChangeDownloadPriorityAsync(Guid id, DownloadPriority priority, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, $"api/downloads/{id}/priority", new ChangePriorityRequest { Priority = priority }, cancellationToken);
+
+    public async Task<int?> PauseAllAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await _httpClient.PostAsync("api/downloads/pause-all", null, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        return await response.Content.ReadFromJsonAsync<int>(cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<bool> ClearCompletedAsync(CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, "api/downloads/clear-completed", null, cancellationToken);
+
+    public async Task<List<QueueItem>> GetQueueAsync(CancellationToken cancellationToken = default)
+    {
+        var items = await _httpClient.GetFromJsonAsync<List<QueueItem>>("api/queue", cancellationToken)
+            .ConfigureAwait(false);
+        return items ?? [];
+    }
+
+    public Task<bool> MoveQueueAsync(Guid id, string action, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, $"api/queue/{id}/{action}", null, cancellationToken);
+
+    public Task<bool> ChangeQueuePriorityAsync(Guid id, DownloadPriority priority, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Post, $"api/queue/{id}/priority", new ChangePriorityRequest { Priority = priority }, cancellationToken);
+
+    public async Task<StatsSnapshot?> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        return await _httpClient.GetFromJsonAsync<StatsSnapshot>("api/stats", cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<SpeedLimitResponseModel?> GetSpeedLimitAsync(CancellationToken cancellationToken = default)
+    {
+        return await _httpClient.GetFromJsonAsync<SpeedLimitResponseModel>("api/config/speed-limit", cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public Task<bool> UpdateSpeedLimitAsync(UpdateSpeedLimitRequestModel request, CancellationToken cancellationToken = default) =>
+        SendCommandAsync(HttpMethod.Put, "api/config/speed-limit", request, cancellationToken);
+
     public async Task<bool> CheckHealthAsync(CancellationToken cancellationToken = default)
     {
         try
@@ -26,10 +97,54 @@ public sealed class KurioApiClient
             return false;
         }
     }
+
+    private async Task<bool> SendCommandAsync(HttpMethod method, string path, object? payload, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(method, path)
+        {
+            Content = payload is null ? null : JsonContent.Create(payload)
+        };
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        return response.IsSuccessStatusCode;
+    }
 }
 
 internal static partial class KurioApiClientLogging
 {
     [LoggerMessage(EventId = 1, Level = LogLevel.Error, Message = "Health check failed")]
     public static partial void LogHealthCheckFailed(this ILogger logger, Exception exception);
+}
+
+public sealed record SpeedLimitResponseModel
+{
+    public bool Enabled { get; set; }
+
+    public long MaxDownloadSpeedBytesPerSecond { get; set; }
+
+    public long MaxUploadSpeedBytesPerSecond { get; set; }
+
+    public long CurrentLimitBytesPerSecond { get; set; }
+}
+
+public sealed record UpdateSpeedLimitRequestModel
+{
+    public bool Enabled { get; set; }
+
+    public long MaxDownloadSpeedBytesPerSecond { get; set; }
+
+    public long MaxUploadSpeedBytesPerSecond { get; set; }
+}
+
+public sealed record CreateDownloadRequest
+{
+    public string Url { get; set; } = string.Empty;
+
+    public string? FileName { get; set; }
+
+    public string? DestinationDirectory { get; set; }
+
+    public int? MaxConnections { get; set; }
+
+    public DownloadPriority Priority { get; set; } = DownloadPriority.Normal;
 }

--- a/src/Kurio.Web/Services/KurioServerOptions.cs
+++ b/src/Kurio.Web/Services/KurioServerOptions.cs
@@ -1,0 +1,15 @@
+namespace KuriousLabs.Kurio.Web.Services;
+
+public sealed class KurioServerOptions
+{
+    public Uri BaseUrl { get; init; } = new("https://localhost:5001");
+
+    public HubEndpoints Hubs { get; init; } = new();
+
+    public sealed class HubEndpoints
+    {
+        public string Downloads { get; init; } = "/hubs/downloads";
+        public string Queue { get; init; } = "/hubs/queue";
+        public string Stats { get; init; } = "/hubs/stats";
+    }
+}

--- a/src/Kurio.Web/Services/KurioServerOptions.cs
+++ b/src/Kurio.Web/Services/KurioServerOptions.cs
@@ -6,10 +6,18 @@ public sealed class KurioServerOptions
 
     public HubEndpoints Hubs { get; init; } = new();
 
+    public AuthenticationOptions? Authentication { get; init; }
+
     public sealed class HubEndpoints
     {
         public string Downloads { get; init; } = "/hubs/downloads";
         public string Queue { get; init; } = "/hubs/queue";
         public string Stats { get; init; } = "/hubs/stats";
+    }
+
+    public sealed class AuthenticationOptions
+    {
+        public bool Enabled { get; init; }
+        public string? ApiKey { get; init; }
     }
 }

--- a/src/Kurio.Web/Services/KurioServerOptionsValidator.cs
+++ b/src/Kurio.Web/Services/KurioServerOptionsValidator.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Options;
+
+namespace KuriousLabs.Kurio.Web.Services;
+
+internal sealed class KurioServerOptionsValidator : IValidateOptions<KurioServerOptions>
+{
+    public ValidateOptionsResult Validate(string? name, KurioServerOptions options)
+    {
+        if (options.BaseUrl is null)
+        {
+            return ValidateOptionsResult.Fail("KurioServer:BaseUrl must be set.");
+        }
+
+        if (!options.BaseUrl.IsAbsoluteUri)
+        {
+            return ValidateOptionsResult.Fail("KurioServer:BaseUrl must be an absolute URI.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Hubs?.Downloads))
+        {
+            return ValidateOptionsResult.Fail("KurioServer:Hubs:Downloads must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Hubs.Queue))
+        {
+            return ValidateOptionsResult.Fail("KurioServer:Hubs:Queue must be set.");
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Hubs.Stats))
+        {
+            return ValidateOptionsResult.Fail("KurioServer:Hubs:Stats must be set.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Kurio.Web/Shared/ConnectionStatus.razor
+++ b/src/Kurio.Web/Shared/ConnectionStatus.razor
@@ -1,0 +1,49 @@
+@implements IDisposable
+@inject ConnectionStateService ConnectionState
+
+<span class="status @CssClass">
+    @StatusText
+    <small title="Last checked (UTC)">@TimestampText</small>
+</span>
+
+@code {
+    private ConnectionStatusSnapshot _snapshot = new(ConnectionStatusKind.Unknown, DateTimeOffset.UtcNow, "Pending");
+
+    private string StatusText => _snapshot.Status switch
+    {
+        ConnectionStatusKind.Connected => "Connected",
+        ConnectionStatusKind.Connecting => "Connecting",
+        ConnectionStatusKind.Reconnecting => "Reconnecting",
+        ConnectionStatusKind.Disconnected => "Disconnected",
+        ConnectionStatusKind.Error => _snapshot.Message ?? "Unavailable",
+        _ => "Unknown"
+    };
+
+    private string CssClass => _snapshot.Status switch
+    {
+        ConnectionStatusKind.Connected => "ok",
+        ConnectionStatusKind.Connecting or ConnectionStatusKind.Reconnecting => "warn",
+        ConnectionStatusKind.Disconnected or ConnectionStatusKind.Error => "error",
+        _ => "warn"
+    };
+
+    private string TimestampText => _snapshot.UpdatedAtUtc.ToString("u");
+
+    protected override async Task OnInitializedAsync()
+    {
+        ConnectionState.Changed += OnChanged;
+        _snapshot = ConnectionState.Current;
+        await ConnectionState.TriggerProbeAsync();
+    }
+
+    private void OnChanged(ConnectionStatusSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        ConnectionState.Changed -= OnChanged;
+    }
+}

--- a/src/Kurio.Web/Shared/MainLayout.razor
+++ b/src/Kurio.Web/Shared/MainLayout.razor
@@ -1,0 +1,19 @@
+@inherits LayoutComponentBase
+
+<PageTitle>Kurio Dashboard</PageTitle>
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <header class="top-bar">
+            <h1>Kurio Dashboard</h1>
+            <ConnectionStatus />
+        </header>
+        <article class="content">
+            @Body
+        </article>
+    </main>
+</div>

--- a/src/Kurio.Web/Shared/NavMenu.razor
+++ b/src/Kurio.Web/Shared/NavMenu.razor
@@ -1,0 +1,9 @@
+<nav>
+    <ul>
+        <li><NavLink href="/" Match="NavLinkMatch.All">Overview</NavLink></li>
+        <li><NavLink href="/downloads">Downloads</NavLink></li>
+        <li><NavLink href="/queue">Queue</NavLink></li>
+        <li><NavLink href="/stats">Stats</NavLink></li>
+        <li><NavLink href="/settings">Settings</NavLink></li>
+    </ul>
+</nav>

--- a/src/Kurio.Web/_Imports.razor
+++ b/src/Kurio.Web/_Imports.razor
@@ -2,7 +2,12 @@
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.SignalR.Client
 @using Microsoft.JSInterop
 @using KuriousLabs.Kurio.Web
 @using KuriousLabs.Kurio.Web.Shared
 @using KuriousLabs.Kurio.Web.Services
+@using KuriousLabs.Kurio.Contracts.Downloads
+@using KuriousLabs.Kurio.Contracts.Queue
+@using KuriousLabs.Kurio.Contracts.Stats
+@using KuriousLabs.Kurio.Contracts.Hubs

--- a/src/Kurio.Web/_Imports.razor
+++ b/src/Kurio.Web/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using KuriousLabs.Kurio.Web
+@using KuriousLabs.Kurio.Web.Shared
+@using KuriousLabs.Kurio.Web.Services

--- a/src/Kurio.Web/appsettings.Development.json
+++ b/src/Kurio.Web/appsettings.Development.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "KurioServer": {
+    "BaseUrl": "https://localhost:5001",
+    "Hubs": {
+      "Downloads": "/hubs/downloads",
+      "Queue": "/hubs/queue",
+      "Stats": "/hubs/stats"
+    }
+  }
+}

--- a/src/Kurio.Web/appsettings.Development.json
+++ b/src/Kurio.Web/appsettings.Development.json
@@ -7,7 +7,7 @@
     }
   },
   "KurioServer": {
-    "BaseUrl": "https://localhost:5001",
+    "BaseUrl": "https://localhost:7206",
     "Hubs": {
       "Downloads": "/hubs/downloads",
       "Queue": "/hubs/queue",

--- a/src/Kurio.Web/appsettings.json
+++ b/src/Kurio.Web/appsettings.json
@@ -12,6 +12,14 @@
       "Downloads": "/hubs/downloads",
       "Queue": "/hubs/queue",
       "Stats": "/hubs/stats"
+    },
+    "Authentication": {
+      "Enabled": false,
+      "ApiKey": ""
     }
+  },
+  "Authentication": {
+    "Enabled": false,
+    "AllowAnonymous": true
   }
 }

--- a/src/Kurio.Web/appsettings.json
+++ b/src/Kurio.Web/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "KurioServer": {
+    "BaseUrl": "https://localhost:5001",
+    "Hubs": {
+      "Downloads": "/hubs/downloads",
+      "Queue": "/hubs/queue",
+      "Stats": "/hubs/stats"
+    }
+  }
+}

--- a/src/Kurio.Web/appsettings.json
+++ b/src/Kurio.Web/appsettings.json
@@ -7,7 +7,7 @@
     }
   },
   "KurioServer": {
-    "BaseUrl": "https://localhost:5001",
+    "BaseUrl": "https://localhost:7206",
     "Hubs": {
       "Downloads": "/hubs/downloads",
       "Queue": "/hubs/queue",

--- a/src/Kurio.Web/wwwroot/css/app.css
+++ b/src/Kurio.Web/wwwroot/css/app.css
@@ -36,3 +36,60 @@ main { padding: 1.5rem; }
 .status { padding: 0.35rem 0.75rem; border-radius: 999px; font-weight: 600; }
 .status.ok { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
 .status.warn { background: rgba(245, 158, 11, 0.15); color: var(--warn); }
+.status.error { background: rgba(248, 113, 113, 0.15); color: #f87171; }
+.muted { color: rgba(226, 232, 240, 0.6); }
+
+.toolbar { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; margin-bottom: 1rem; }
+.filters { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; }
+
+.add-form { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.5rem; flex: 1; }
+.add-form input, .add-form select { width: 100%; }
+
+.data-table { width: 100%; border-collapse: collapse; }
+.data-table th, .data-table td { padding: 0.5rem 0.75rem; text-align: left; border-bottom: 1px solid rgba(255,255,255,0.05); }
+.data-table th { font-weight: 600; color: rgba(226, 232, 240, 0.8); }
+.data-table tr:hover { background: rgba(255, 255, 255, 0.03); }
+
+.title { font-weight: 600; }
+.sub { color: rgba(226, 232, 240, 0.65); font-size: 0.9rem; }
+.badge { padding: 0.15rem 0.6rem; border-radius: 999px; font-size: 0.8rem; text-transform: capitalize; }
+.badge.ok { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
+.badge.warn { background: rgba(245, 158, 11, 0.15); color: var(--warn); }
+.badge.error { background: rgba(248, 113, 113, 0.15); color: #f87171; }
+.badge.muted { background: rgba(255,255,255,0.05); color: rgba(226, 232, 240, 0.7); }
+
+.progress { position: relative; width: 100%; height: 8px; background: rgba(255,255,255,0.05); border-radius: 6px; overflow: hidden; }
+.progress.small { height: 6px; }
+.progress .bar { position: absolute; inset: 0; background: linear-gradient(90deg, #38bdf8, #06b6d4); }
+
+.actions { display: flex; gap: 0.25rem; flex-wrap: wrap; }
+
+button { background: rgba(255,255,255,0.08); color: var(--text); border: 1px solid rgba(255,255,255,0.1); padding: 0.45rem 0.75rem; border-radius: 8px; cursor: pointer; }
+button:hover { border-color: var(--accent); }
+button.primary { background: var(--accent); color: #0b1628; border-color: transparent; }
+button.ghost { background: transparent; }
+button.danger { background: rgba(248, 113, 113, 0.2); color: #fca5a5; border-color: rgba(248, 113, 113, 0.4); }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+input, select { background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); color: var(--text); padding: 0.45rem 0.6rem; border-radius: 8px; }
+input:focus, select:focus { outline: 1px solid var(--accent); }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; margin: 1rem 0; }
+.card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.05); border-radius: 10px; padding: 1rem; }
+.card .label { font-size: 0.9rem; color: rgba(226, 232, 240, 0.7); }
+.card .value { font-size: 1.4rem; font-weight: 700; margin-top: 0.35rem; }
+
+.alert { padding: 0.75rem 1rem; border-radius: 10px; margin-bottom: 0.75rem; }
+.alert.error { background: rgba(248, 113, 113, 0.1); color: #fecdd3; border: 1px solid rgba(248, 113, 113, 0.4); }
+
+.section-header { display: flex; justify-content: space-between; align-items: center; margin: 1.25rem 0 0.75rem; }
+.download-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.75rem; }
+.download-list li { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.05); padding: 0.75rem; border-radius: 10px; }
+.download-list .meta { display: flex; gap: 0.5rem; flex-wrap: wrap; color: rgba(226, 232, 240, 0.7); }
+
+.stack { display: grid; gap: 0.65rem; max-width: 440px; }
+
+@media (max-width: 960px) {
+    .page { grid-template-columns: 1fr; }
+    .sidebar { border-right: none; border-bottom: 1px solid rgba(255,255,255,0.05); }
+}

--- a/src/Kurio.Web/wwwroot/css/app.css
+++ b/src/Kurio.Web/wwwroot/css/app.css
@@ -1,0 +1,38 @@
+:root {
+    --bg: #0f172a;
+    --panel: #1e293b;
+    --text: #e2e8f0;
+    --accent: #38bdf8;
+    --warn: #f59e0b;
+}
+
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    font-family: "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+}
+
+.page {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    min-height: 100vh;
+}
+.sidebar {
+    background: var(--panel);
+    padding: 1rem;
+    border-right: 1px solid rgba(255,255,255,0.05);
+}
+nav ul { list-style: none; padding: 0; margin: 0; }
+nav li { margin-bottom: 0.5rem; }
+nav a { color: var(--text); text-decoration: none; padding: 0.5rem 0.75rem; display: block; border-radius: 6px; }
+nav a.active { background: rgba(56, 189, 248, 0.15); color: var(--accent); }
+
+main { padding: 1.5rem; }
+.top-bar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; }
+.content { background: var(--panel); padding: 1.5rem; border-radius: 10px; border: 1px solid rgba(255,255,255,0.05); }
+
+.status { padding: 0.35rem 0.75rem; border-radius: 999px; font-weight: 600; }
+.status.ok { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
+.status.warn { background: rgba(245, 158, 11, 0.15); color: var(--warn); }

--- a/test/Kurio.Server.Tests/Hubs/DownloadHubTests.cs
+++ b/test/Kurio.Server.Tests/Hubs/DownloadHubTests.cs
@@ -1,0 +1,274 @@
+using FluentAssertions;
+using KuriousLabs.Kurio.Contracts.Downloads;
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using CoreModels = KuriousLabs.Kurio.Core.Models;
+
+namespace Kurio.Server.Tests.Hubs;
+
+public sealed class DownloadHubTests
+{
+    private readonly Mock<IDownloadEngine> _mockEngine;
+    private readonly Mock<ILogger<DownloadHub>> _mockLogger;
+    private readonly Mock<IHubCallerClients<IDownloadsClient>> _mockClients;
+    private readonly Mock<IDownloadsClient> _mockCaller;
+    private readonly Mock<IGroupManager> _mockGroups;
+    private readonly Mock<HubCallerContext> _mockContext;
+    private readonly DownloadHub _hub;
+
+    public DownloadHubTests()
+    {
+        _mockEngine = new Mock<IDownloadEngine>();
+        _mockLogger = new Mock<ILogger<DownloadHub>>();
+        _mockClients = new Mock<IHubCallerClients<IDownloadsClient>>();
+        _mockCaller = new Mock<IDownloadsClient>();
+        _mockGroups = new Mock<IGroupManager>();
+        _mockContext = new Mock<HubCallerContext>();
+
+        _mockClients.Setup(c => c.Caller).Returns(_mockCaller.Object);
+        _mockContext.Setup(c => c.ConnectionId).Returns("test-connection-id");
+
+        _hub = new DownloadHub(_mockEngine.Object, _mockLogger.Object)
+        {
+            Clients = _mockClients.Object,
+            Groups = _mockGroups.Object,
+            Context = _mockContext.Object
+        };
+    }
+
+    [Fact]
+    public async Task SubscribeDownloadsAsync_AddsClientToGroup()
+    {
+        // Arrange
+        var request = new DownloadSubscriptionRequest { States = DownloadStateFilter.All };
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns([]);
+
+        // Act
+        await _hub.SubscribeDownloadsAsync(request);
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.AddToGroupAsync("test-connection-id", DownloadHub.GroupName, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeDownloadsAsync_SendsSnapshot()
+    {
+        // Arrange
+        var request = new DownloadSubscriptionRequest { States = DownloadStateFilter.Active };
+        var mockTask = CreateMockDownloadTask("https://example.com/file.zip", CoreModels.DownloadState.Downloading);
+        
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns([mockTask]);
+
+        // Act
+        await _hub.SubscribeDownloadsAsync(request);
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.ReceiveSnapshotAsync(It.Is<List<DownloadInfo>>(list => list.Count == 1)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeDownloadsAsync_FiltersCompletedDownloads_WhenIncludeCompletedIsFalse()
+    {
+        // Arrange
+        var request = new DownloadSubscriptionRequest 
+        { 
+            States = DownloadStateFilter.All,
+            IncludeCompleted = false
+        };
+        
+        var activeTask = CreateMockDownloadTask("https://example.com/active.zip", CoreModels.DownloadState.Downloading);
+        var completedTask = CreateMockDownloadTask("https://example.com/completed.zip", CoreModels.DownloadState.Completed);
+        
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns([activeTask, completedTask]);
+
+        // Act
+        await _hub.SubscribeDownloadsAsync(request);
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.ReceiveSnapshotAsync(It.Is<List<DownloadInfo>>(
+                list => list.Count == 1 && list[0].State == DownloadState.Downloading)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeDownloadsAsync_AppliesLimit_WhenLimitSpecified()
+    {
+        // Arrange
+        var request = new DownloadSubscriptionRequest 
+        { 
+            States = DownloadStateFilter.All,
+            Limit = 2
+        };
+        
+        var tasks = new[]
+        {
+            CreateMockDownloadTask("https://example.com/file1.zip", CoreModels.DownloadState.Downloading),
+            CreateMockDownloadTask("https://example.com/file2.zip", CoreModels.DownloadState.Downloading),
+            CreateMockDownloadTask("https://example.com/file3.zip", CoreModels.DownloadState.Downloading)
+        };
+        
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns(tasks);
+
+        // Act
+        await _hub.SubscribeDownloadsAsync(request);
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.ReceiveSnapshotAsync(It.Is<List<DownloadInfo>>(list => list.Count == 2)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeDownloadsAsync_FiltersByCategory_WhenCategorySpecified()
+    {
+        // Arrange
+        var request = new DownloadSubscriptionRequest 
+        { 
+            States = DownloadStateFilter.All,
+            Category = "videos"
+        };
+        
+        var videoTask = CreateMockDownloadTask("https://example.com/video.mp4", CoreModels.DownloadState.Downloading, "videos");
+        var docTask = CreateMockDownloadTask("https://example.com/doc.pdf", CoreModels.DownloadState.Downloading, "documents");
+        
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns([videoTask, docTask]);
+
+        // Act
+        await _hub.SubscribeDownloadsAsync(request);
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.ReceiveSnapshotAsync(It.Is<List<DownloadInfo>>(
+                list => list.Count == 1 && list[0].FileName == "video.mp4")),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UnsubscribeDownloadsAsync_RemovesClientFromGroup()
+    {
+        // Act
+        await _hub.UnsubscribeDownloadsAsync();
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.RemoveFromGroupAsync("test-connection-id", DownloadHub.GroupName, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestSnapshotAsync_SendsSnapshot()
+    {
+        // Arrange
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns([]);
+
+        // Act
+        await _hub.RequestSnapshotAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.ReceiveSnapshotAsync(It.IsAny<List<DownloadInfo>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeDownloadsAsync_OrdersByPriorityThenCreatedAt()
+    {
+        // Arrange
+        var request = new DownloadSubscriptionRequest { States = DownloadStateFilter.All };
+        
+        var lowPriorityOld = CreateMockDownloadTask(
+            "https://example.com/low-old.zip", 
+            CoreModels.DownloadState.Downloading,
+            priority: CoreModels.DownloadPriority.Low,
+            createdAt: DateTime.UtcNow.AddHours(-2));
+            
+        var highPriorityNew = CreateMockDownloadTask(
+            "https://example.com/high-new.zip", 
+            CoreModels.DownloadState.Downloading,
+            priority: CoreModels.DownloadPriority.High,
+            createdAt: DateTime.UtcNow);
+            
+        var normalPriority = CreateMockDownloadTask(
+            "https://example.com/normal.zip", 
+            CoreModels.DownloadState.Downloading,
+            priority: CoreModels.DownloadPriority.Normal,
+            createdAt: DateTime.UtcNow.AddHours(-1));
+        
+        _mockEngine.Setup(e => e.GetDownloads(It.IsAny<CoreModels.DownloadStateFilter>()))
+            .Returns([lowPriorityOld, normalPriority, highPriorityNew]);
+
+        // Act
+        await _hub.SubscribeDownloadsAsync(request);
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.ReceiveSnapshotAsync(It.Is<List<DownloadInfo>>(list =>
+                list.Count == 3 &&
+                list[0].FileName == "high-new.zip" &&
+                list[1].FileName == "normal.zip" &&
+                list[2].FileName == "low-old.zip")),
+            Times.Once);
+    }
+
+    private static IDownloadTask CreateMockDownloadTask(
+        string url,
+        CoreModels.DownloadState state,
+        string? category = null,
+        CoreModels.DownloadPriority priority = CoreModels.DownloadPriority.Normal,
+        DateTime? createdAt = null)
+    {
+        var uri = new Uri(url);
+        var fileName = Path.GetFileName(uri.LocalPath);
+        
+        return new TestFakeDownloadTask
+        {
+            Id = Guid.NewGuid(),
+            Url = uri,
+            FileName = fileName,
+            State = state,
+            Priority = priority,
+            CreatedAt = createdAt ?? DateTime.UtcNow,
+            Options = new CoreModels.DownloadOptions
+            {
+                DestinationDirectory = "/tmp",
+                Category = category,
+                MaxConnections = 4
+            },
+            Progress = new CoreModels.DownloadProgress { TaskId = Guid.NewGuid() }
+        };
+    }
+}
+
+file sealed class TestFakeDownloadTask : IDownloadTask
+{
+    public Guid Id { get; init; }
+    public required Uri Url { get; init; }
+    public required string FileName { get; init; }
+    public long FileSize { get; init; }
+    public CoreModels.DownloadState State { get; init; }
+    public CoreModels.DownloadPriority Priority { get; set; }
+    public CoreModels.DownloadProgress Progress { get; init; } = new();
+    public CoreModels.DownloadOptions Options { get; init; } = new() { DestinationDirectory = "downloads" };
+    public CoreModels.ResourceMetadata Metadata { get; init; } = new();
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+    public DateTime? StartedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+    public CoreModels.DownloadError? LastError { get; init; }
+    public int RetryCount { get; init; }
+    public CoreModels.ChecksumResult? ChecksumResult { get; init; }
+}

--- a/test/Kurio.Server.Tests/Hubs/QueueHubTests.cs
+++ b/test/Kurio.Server.Tests/Hubs/QueueHubTests.cs
@@ -1,0 +1,245 @@
+using FluentAssertions;
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Contracts.Queue;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using CoreModels = KuriousLabs.Kurio.Core.Models;
+
+namespace Kurio.Server.Tests.Hubs;
+
+public sealed class QueueHubTests
+{
+    private readonly Mock<IDownloadQueueManager> _mockQueueManager;
+    private readonly Mock<ILogger<QueueHub>> _mockLogger;
+    private readonly Mock<IHubCallerClients<IQueueClient>> _mockClients;
+    private readonly Mock<IQueueClient> _mockCaller;
+    private readonly Mock<IGroupManager> _mockGroups;
+    private readonly Mock<HubCallerContext> _mockContext;
+    private readonly QueueHub _hub;
+
+    public QueueHubTests()
+    {
+        _mockQueueManager = new Mock<IDownloadQueueManager>();
+        _mockLogger = new Mock<ILogger<QueueHub>>();
+        _mockClients = new Mock<IHubCallerClients<IQueueClient>>();
+        _mockCaller = new Mock<IQueueClient>();
+        _mockGroups = new Mock<IGroupManager>();
+        _mockContext = new Mock<HubCallerContext>();
+
+        _mockClients.Setup(c => c.Caller).Returns(_mockCaller.Object);
+        _mockContext.Setup(c => c.ConnectionId).Returns("test-connection-id");
+
+        _hub = new QueueHub(_mockQueueManager.Object, _mockLogger.Object)
+        {
+            Clients = _mockClients.Object,
+            Groups = _mockGroups.Object,
+            Context = _mockContext.Object
+        };
+    }
+
+    [Fact]
+    public async Task SubscribeQueueAsync_AddsClientToGroup()
+    {
+        // Arrange
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns([]);
+
+        // Act
+        await _hub.SubscribeQueueAsync();
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.AddToGroupAsync("test-connection-id", QueueHub.GroupName, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeQueueAsync_SendsQueueSnapshot()
+    {
+        // Arrange
+        var task1 = CreateMockQueuedTask("https://example.com/file1.zip", CoreModels.DownloadPriority.High);
+        var task2 = CreateMockQueuedTask("https://example.com/file2.zip", CoreModels.DownloadPriority.Normal);
+        
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns([task1, task2]);
+
+        // Act
+        await _hub.SubscribeQueueAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.QueueSnapshotAsync(It.Is<List<QueueItem>>(list => 
+                list.Count == 2 &&
+                list[0].Position == 1 &&
+                list[1].Position == 2)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeQueueAsync_HandlesEmptyQueue()
+    {
+        // Arrange
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns([]);
+
+        // Act
+        await _hub.SubscribeQueueAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.QueueSnapshotAsync(It.Is<List<QueueItem>>(list => list.Count == 0)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UnsubscribeQueueAsync_RemovesClientFromGroup()
+    {
+        // Act
+        await _hub.UnsubscribeQueueAsync();
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.RemoveFromGroupAsync("test-connection-id", QueueHub.GroupName, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestQueueSnapshotAsync_SendsSnapshot()
+    {
+        // Arrange
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns([]);
+
+        // Act
+        await _hub.RequestQueueSnapshotAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.QueueSnapshotAsync(It.IsAny<List<QueueItem>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeQueueAsync_AssignsCorrectPositions()
+    {
+        // Arrange
+        var tasks = new[]
+        {
+            CreateMockQueuedTask("https://example.com/file1.zip", CoreModels.DownloadPriority.High),
+            CreateMockQueuedTask("https://example.com/file2.zip", CoreModels.DownloadPriority.Normal),
+            CreateMockQueuedTask("https://example.com/file3.zip", CoreModels.DownloadPriority.Low)
+        };
+        
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns(tasks);
+
+        // Act
+        await _hub.SubscribeQueueAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.QueueSnapshotAsync(It.Is<List<QueueItem>>(list =>
+                list.Count == 3 &&
+                list[0].Position == 1 &&
+                list[1].Position == 2 &&
+                list[2].Position == 3)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeQueueAsync_MapsTaskPropertiesCorrectly()
+    {
+        // Arrange
+        var taskId = Guid.NewGuid();
+        var task = new CoreModels.DownloadTask(
+            taskId,
+            new Uri("https://example.com/file.zip"),
+            new CoreModels.DownloadOptions
+            {
+                Destination = "/tmp",
+                FileName = "file.zip",
+                Category = "general",
+                MaxConnections = 4
+            },
+            CoreModels.DownloadState.Queued,
+            CoreModels.DownloadPriority.High,
+            DateTime.UtcNow,
+            null,
+            null);
+        
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns([task]);
+
+        // Act
+        await _hub.SubscribeQueueAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.QueueSnapshotAsync(It.Is<List<QueueItem>>(list =>
+                list.Count == 1 &&
+                list[0].DownloadId == taskId &&
+                list[0].Priority == Contracts.Downloads.DownloadPriority.High &&
+                list[0].Position == 1)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task MultipleClients_CanSubscribeConcurrently()
+    {
+        // Arrange
+        _mockQueueManager.Setup(q => q.GetQueuedTasks()).Returns([]);
+
+        // Act
+        await Task.WhenAll(
+            _hub.SubscribeQueueAsync(),
+            _hub.SubscribeQueueAsync(),
+            _hub.SubscribeQueueAsync()
+        );
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.AddToGroupAsync("test-connection-id", QueueHub.GroupName, default),
+            Times.Exactly(3));
+    }
+
+    private static IDownloadTask CreateMockQueuedTask(
+        string url,
+        CoreModels.DownloadPriority priority)
+    {
+        var uri = new Uri(url);
+        var fileName = Path.GetFileName(uri.LocalPath);
+        
+        return new TestFakeDownloadTask
+        {
+            Id = Guid.NewGuid(),
+            Url = uri,
+            FileName = fileName,
+            State = CoreModels.DownloadState.Queued,
+            Priority = priority,
+            CreatedAt = DateTime.UtcNow,
+            Options = new CoreModels.DownloadOptions
+            {
+                DestinationDirectory = "/tmp",
+                Category = "general",
+                MaxConnections = 4
+            },
+            Progress = new CoreModels.DownloadProgress { TaskId = Guid.NewGuid() }
+        };
+    }
+}
+
+file sealed class TestFakeDownloadTask : IDownloadTask
+{
+    public Guid Id { get; init; }
+    public required Uri Url { get; init; }
+    public required string FileName { get; init; }
+    public long FileSize { get; init; }
+    public CoreModels.DownloadState State { get; init; }
+    public CoreModels.DownloadPriority Priority { get; set; }
+    public CoreModels.DownloadProgress Progress { get; init; } = new();
+    public CoreModels.DownloadOptions Options { get; init; } = new() { DestinationDirectory = "downloads" };
+    public CoreModels.ResourceMetadata Metadata { get; init; } = new();
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+    public DateTime? StartedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+    public CoreModels.DownloadError? LastError { get; init; }
+    public int RetryCount { get; init; }
+    public CoreModels.ChecksumResult? ChecksumResult { get; init; }
+}

--- a/test/Kurio.Server.Tests/Hubs/StatsHubTests.cs
+++ b/test/Kurio.Server.Tests/Hubs/StatsHubTests.cs
@@ -1,0 +1,267 @@
+using FluentAssertions;
+using KuriousLabs.Kurio.Contracts.Hubs;
+using KuriousLabs.Kurio.Contracts.Stats;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using CoreModels = KuriousLabs.Kurio.Core.Models;
+
+namespace Kurio.Server.Tests.Hubs;
+
+public sealed class StatsHubTests
+{
+    private readonly Mock<IStatisticsService> _mockStatisticsService;
+    private readonly Mock<IDownloadQueueManager> _mockQueueManager;
+    private readonly Mock<ILogger<StatsHub>> _mockLogger;
+    private readonly Mock<IHubCallerClients<IStatsClient>> _mockClients;
+    private readonly Mock<IStatsClient> _mockCaller;
+    private readonly Mock<IGroupManager> _mockGroups;
+    private readonly Mock<HubCallerContext> _mockContext;
+    private readonly StatsHub _hub;
+
+    public StatsHubTests()
+    {
+        _mockStatisticsService = new Mock<IStatisticsService>();
+        _mockQueueManager = new Mock<IDownloadQueueManager>();
+        _mockLogger = new Mock<ILogger<StatsHub>>();
+        _mockClients = new Mock<IHubCallerClients<IStatsClient>>();
+        _mockCaller = new Mock<IStatsClient>();
+        _mockGroups = new Mock<IGroupManager>();
+        _mockContext = new Mock<HubCallerContext>();
+
+        _mockClients.Setup(c => c.Caller).Returns(_mockCaller.Object);
+        _mockContext.Setup(c => c.ConnectionId).Returns("test-connection-id");
+        _mockContext.Setup(c => c.ConnectionAborted).Returns(CancellationToken.None);
+
+        _hub = new StatsHub(
+            _mockStatisticsService.Object,
+            _mockQueueManager.Object,
+            _mockLogger.Object)
+        {
+            Clients = _mockClients.Object,
+            Groups = _mockGroups.Object,
+            Context = _mockContext.Object
+        };
+    }
+
+    [Fact]
+    public async Task SubscribeStatsAsync_AddsClientToGroup()
+    {
+        // Arrange
+        var stats = CreateMockStatistics();
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(0);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(0);
+
+        // Act
+        await _hub.SubscribeStatsAsync();
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.AddToGroupAsync("test-connection-id", StatsHub.GroupName, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeStatsAsync_SendsStatsSnapshot()
+    {
+        // Arrange
+        var stats = CreateMockStatistics(
+            completedDownloads: 10,
+            failedDownloads: 2,
+            totalBytesDownloaded: 1024000,
+            averageSpeed: 512000);
+            
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(3);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(5);
+
+        // Act
+        await _hub.SubscribeStatsAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.StatsSnapshotAsync(It.Is<StatsSnapshot>(snapshot =>
+                snapshot.CompletedCount == 10 &&
+                snapshot.FailedCount == 2 &&
+                snapshot.TotalBytesDownloaded == 1024000 &&
+                snapshot.ActiveCount == 3 &&
+                snapshot.QueuedCount == 5)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeStatsAsync_MapsAllStatisticsFields()
+    {
+        // Arrange
+        var startedAt = DateTime.UtcNow.AddHours(-2);
+        var stats = new CoreModels.DownloadStatistics
+        {
+            AllTimeCompletedDownloads = 50,
+            AllTimeFailedDownloads = 5,
+            AllTimeBytesDownloaded = 10_000_000,
+            AverageDownloadSpeed = 1_000_000,
+            SessionStartedAt = startedAt
+        };
+        
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(2);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(8);
+
+        // Act
+        await _hub.SubscribeStatsAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.StatsSnapshotAsync(It.Is<StatsSnapshot>(snapshot =>
+                snapshot.CompletedCount == 50 &&
+                snapshot.FailedCount == 5 &&
+                snapshot.TotalBytesDownloaded == 10_000_000 &&
+                snapshot.AverageThroughputBytesPerSecond == 1_000_000 &&
+                snapshot.CurrentThroughputBytesPerSecond == 1_000_000 &&
+                snapshot.ActiveCount == 2 &&
+                snapshot.QueuedCount == 8 &&
+                snapshot.StartedAt == new DateTimeOffset(startedAt))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UnsubscribeStatsAsync_RemovesClientFromGroup()
+    {
+        // Act
+        await _hub.UnsubscribeStatsAsync();
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.RemoveFromGroupAsync("test-connection-id", StatsHub.GroupName, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestStatsSnapshotAsync_SendsSnapshot()
+    {
+        // Arrange
+        var stats = CreateMockStatistics();
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(0);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(0);
+
+        // Act
+        await _hub.RequestStatsSnapshotAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.StatsSnapshotAsync(It.IsAny<StatsSnapshot>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeStatsAsync_HandlesZeroStatistics()
+    {
+        // Arrange
+        var stats = CreateMockStatistics(0, 0, 0, 0);
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(0);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(0);
+
+        // Act
+        await _hub.SubscribeStatsAsync();
+
+        // Assert
+        _mockCaller.Verify(
+            c => c.StatsSnapshotAsync(It.Is<StatsSnapshot>(snapshot =>
+                snapshot.CompletedCount == 0 &&
+                snapshot.FailedCount == 0 &&
+                snapshot.TotalBytesDownloaded == 0 &&
+                snapshot.AverageThroughputBytesPerSecond == 0 &&
+                snapshot.ActiveCount == 0 &&
+                snapshot.QueuedCount == 0)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeStatsAsync_UsesConnectionAbortedToken()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        _mockContext.Setup(c => c.ConnectionAborted).Returns(cts.Token);
+        
+        var stats = CreateMockStatistics();
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(cts.Token))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(0);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(0);
+
+        // Act
+        await _hub.SubscribeStatsAsync();
+
+        // Assert
+        _mockStatisticsService.Verify(
+            s => s.GetStatisticsAsync(cts.Token),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SubscribeStatsAsync_RetrievesQueueCountsFromQueueManager()
+    {
+        // Arrange
+        var stats = CreateMockStatistics();
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(7);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(13);
+
+        // Act
+        await _hub.SubscribeStatsAsync();
+
+        // Assert
+        _mockQueueManager.Verify(q => q.GetActiveCount(), Times.AtLeastOnce);
+        _mockQueueManager.Verify(q => q.GetQueuedCount(), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task MultipleClients_CanSubscribeConcurrently()
+    {
+        // Arrange
+        var stats = CreateMockStatistics();
+        _mockStatisticsService.Setup(s => s.GetStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stats);
+        _mockQueueManager.Setup(q => q.GetActiveCount()).Returns(0);
+        _mockQueueManager.Setup(q => q.GetQueuedCount()).Returns(0);
+
+        // Act
+        await Task.WhenAll(
+            _hub.SubscribeStatsAsync(),
+            _hub.SubscribeStatsAsync(),
+            _hub.SubscribeStatsAsync()
+        );
+
+        // Assert
+        _mockGroups.Verify(
+            g => g.AddToGroupAsync("test-connection-id", StatsHub.GroupName, default),
+            Times.Exactly(3));
+    }
+
+    private static CoreModels.DownloadStatistics CreateMockStatistics(
+        int completedDownloads = 0,
+        int failedDownloads = 0,
+        long totalBytesDownloaded = 0,
+        double averageSpeed = 0)
+    {
+        return new CoreModels.DownloadStatistics
+        {
+            AllTimeCompletedDownloads = completedDownloads,
+            AllTimeFailedDownloads = failedDownloads,
+            AllTimeBytesDownloaded = totalBytesDownloaded,
+            AverageDownloadSpeed = averageSpeed,
+            SessionStartedAt = DateTime.UtcNow
+        };
+    }
+}

--- a/test/Kurio.Server.Tests/Kurio.Server.Tests.csproj
+++ b/test/Kurio.Server.Tests/Kurio.Server.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kurio.Server\Kurio.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Kurio.Server.Tests/QueueAndStatsTests.cs
+++ b/test/Kurio.Server.Tests/QueueAndStatsTests.cs
@@ -1,0 +1,381 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using KuriousLabs.Kurio.Contracts.Queue;
+using KuriousLabs.Kurio.Contracts.Stats;
+using KuriousLabs.Kurio.Core.Abstractions;
+using KuriousLabs.Kurio.Server;
+using KuriousLabs.Kurio.Server.Controllers;
+using KuriousLabs.Kurio.Server.Hubs;
+using KuriousLabs.Kurio.Server.Services;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using ContractDownloads = KuriousLabs.Kurio.Contracts.Downloads;
+using CoreModels = KuriousLabs.Kurio.Core.Models;
+
+namespace Kurio.Server.Tests;
+
+public class QueueAndStatsTests : IClassFixture<ServerTestFactory>
+{
+    private readonly ServerTestFactory _factory;
+
+    public QueueAndStatsTests(ServerTestFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task QueueSnapshot_ReturnsOrderedItems()
+    {
+        var client = _factory.WithQueue(queue =>
+        {
+            queue.Seed(
+                FakeDownloadTask.Create("first", CoreModels.DownloadPriority.High),
+                FakeDownloadTask.Create("second", CoreModels.DownloadPriority.Normal));
+        }).CreateClient();
+
+        var response = await client.GetAsync("/api/queue");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var snapshot = await response.Content.ReadFromJsonAsync<List<QueueItem>>();
+        snapshot.Should().NotBeNull();
+        snapshot!.Count.Should().Be(2);
+        snapshot[0].Position.Should().Be(1);
+        snapshot[0].Priority.Should().Be(ContractDownloads.DownloadPriority.High);
+        snapshot[1].Position.Should().Be(2);
+        snapshot[1].Priority.Should().Be(ContractDownloads.DownloadPriority.Normal);
+    }
+
+    [Fact]
+    public async Task ChangePriority_ReordersQueue()
+    {
+        var low = FakeDownloadTask.Create("low", CoreModels.DownloadPriority.Low);
+        var normal = FakeDownloadTask.Create("normal", CoreModels.DownloadPriority.Normal);
+
+        var client = _factory.WithQueue(queue => queue.Seed(low, normal)).CreateClient();
+
+        var changeRequest = new ContractDownloads.ChangePriorityRequest { Priority = ContractDownloads.DownloadPriority.High };
+        var response = await client.PostAsJsonAsync($"/api/queue/{low.Id}/priority", changeRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var snapshot = await client.GetFromJsonAsync<List<QueueItem>>("/api/queue");
+        snapshot.Should().NotBeNull();
+        snapshot!.Count.Should().Be(2);
+        snapshot[0].DownloadId.Should().Be(low.Id);
+        snapshot[0].Priority.Should().Be(ContractDownloads.DownloadPriority.High);
+        snapshot[0].Position.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task StatsSnapshot_MapsStatistics()
+    {
+        var client = _factory.WithStats(stats =>
+        {
+            stats.AllTimeBytesDownloaded = 10_000;
+            stats.AllTimeCompletedDownloads = 5;
+            stats.AllTimeFailedDownloads = 2;
+            stats.AverageDownloadSpeed = 1234;
+            stats.SessionStartedAt = new DateTime(2024, 12, 1, 12, 0, 0, DateTimeKind.Utc);
+        }).WithQueue(queue => queue.SetCounts(active: 1, queued: 2)).CreateClient();
+
+        var snapshot = await client.GetFromJsonAsync<StatsSnapshot>("/api/stats");
+
+        snapshot.Should().NotBeNull();
+        snapshot!.ActiveCount.Should().Be(1);
+        snapshot.QueuedCount.Should().Be(2);
+        snapshot.CompletedCount.Should().Be(5);
+        snapshot.FailedCount.Should().Be(2);
+        snapshot.TotalBytesDownloaded.Should().Be(10_000);
+        snapshot.AverageThroughputBytesPerSecond.Should().Be(1234);
+        snapshot.CurrentThroughputBytesPerSecond.Should().Be(1234);
+        snapshot.StartedAt.Should().Be(new DateTimeOffset(new DateTime(2024, 12, 1, 12, 0, 0, DateTimeKind.Utc)));
+    }
+}
+
+public sealed class ServerTestFactory : WebApplicationFactory<Program>
+{
+    private readonly FakeQueueManager _queueManager = new();
+    private readonly FakeStatisticsService _statisticsService = new();
+
+    public ServerTestFactory WithQueue(Action<FakeQueueManager> configure)
+    {
+        configure(_queueManager);
+        return this;
+    }
+
+    public ServerTestFactory WithStats(Action<CoreModels.DownloadStatistics> configure)
+    {
+        configure(_statisticsService.Statistics);
+        return this;
+    }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<IDownloadEngine>();
+            services.RemoveAll<IDownloadQueueManager>();
+            services.RemoveAll<IStatisticsService>();
+
+            services.AddSingleton<IDownloadEngine, FakeDownloadEngine>();
+            services.AddSingleton<IDownloadQueueManager>(_queueManager);
+            services.AddSingleton<IStatisticsService>(_statisticsService);
+        });
+
+        return base.CreateHost(builder);
+    }
+}
+
+public sealed class FakeDownloadTask : IDownloadTask
+{
+    public Guid Id { get; init; }
+    public required Uri Url { get; init; }
+    public required string FileName { get; init; }
+    public long FileSize { get; init; }
+    public CoreModels.DownloadState State { get; init; }
+    public CoreModels.DownloadPriority Priority { get; set; }
+    public CoreModels.DownloadProgress Progress { get; init; } = new();
+    public CoreModels.DownloadOptions Options { get; init; } = new() { DestinationDirectory = "downloads" };
+    public CoreModels.ResourceMetadata Metadata { get; init; } = new();
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+    public DateTime? StartedAt { get; init; }
+    public DateTime? CompletedAt { get; init; }
+    public CoreModels.DownloadError? LastError { get; init; }
+    public int RetryCount { get; init; }
+    public CoreModels.ChecksumResult? ChecksumResult { get; init; }
+
+    public static FakeDownloadTask Create(string name, CoreModels.DownloadPriority priority)
+    {
+        return new FakeDownloadTask
+        {
+            Id = Guid.NewGuid(),
+            Url = new Uri($"https://example.com/{name}"),
+            FileName = name,
+            Priority = priority,
+            State = CoreModels.DownloadState.Queued,
+            Progress = new CoreModels.DownloadProgress { TaskId = Guid.NewGuid() },
+            Options = new CoreModels.DownloadOptions { DestinationDirectory = "downloads", Category = "default", Priority = priority }
+        };
+    }
+}
+
+public sealed class FakeQueueManager : IDownloadQueueManager
+{
+    private readonly List<IDownloadTask> _queued = new();
+    private int _active;
+
+    public int MaxConcurrentDownloads { get; set; } = 3;
+    public int ActiveDownloadsCount => _active;
+    public int QueuedDownloadsCount => _queued.Count;
+
+    public void Enqueue(IDownloadTask task)
+    {
+        _queued.Add(task);
+        SortQueue();
+    }
+
+    public bool Dequeue(Guid taskId)
+    {
+        var removed = _queued.RemoveAll(t => t.Id == taskId) > 0;
+        return removed;
+    }
+
+    public IDownloadTask? GetNextTask() => _queued.FirstOrDefault();
+
+    public bool ChangePriority(Guid taskId, CoreModels.DownloadPriority newPriority)
+    {
+        var task = _queued.FirstOrDefault(t => t.Id == taskId);
+        if (task is null)
+        {
+            return false;
+        }
+
+        task.Priority = newPriority;
+        SortQueue();
+        return true;
+    }
+
+    public bool MoveUp(Guid taskId)
+    {
+        var index = _queued.FindIndex(t => t.Id == taskId);
+        if (index <= 0)
+        {
+            return false;
+        }
+
+        (_queued[index - 1], _queued[index]) = (_queued[index], _queued[index - 1]);
+        return true;
+    }
+
+    public bool MoveDown(Guid taskId)
+    {
+        var index = _queued.FindIndex(t => t.Id == taskId);
+        if (index < 0 || index >= _queued.Count - 1)
+        {
+            return false;
+        }
+
+        (_queued[index + 1], _queued[index]) = (_queued[index], _queued[index + 1]);
+        return true;
+    }
+
+    public bool MoveToTop(Guid taskId)
+    {
+        var index = _queued.FindIndex(t => t.Id == taskId);
+        if (index <= 0)
+        {
+            return false;
+        }
+
+        var task = _queued[index];
+        _queued.RemoveAt(index);
+        _queued.Insert(0, task);
+        return true;
+    }
+
+    public bool MoveToBottom(Guid taskId)
+    {
+        var index = _queued.FindIndex(t => t.Id == taskId);
+        if (index < 0)
+        {
+            return false;
+        }
+
+        var task = _queued[index];
+        _queued.RemoveAt(index);
+        _queued.Add(task);
+        return true;
+    }
+
+    public IReadOnlyList<IDownloadTask> GetQueuedTasks() => _queued.ToList();
+    public IReadOnlyList<IDownloadTask> GetActiveTasks() => Array.Empty<IDownloadTask>();
+
+    public void MarkAsStarted(Guid taskId)
+    {
+        // Not needed for tests
+    }
+
+    public void MarkAsCompleted(Guid taskId)
+    {
+        // Not needed for tests
+    }
+
+    public void MarkAsFailed(Guid taskId)
+    {
+        // Not needed for tests
+    }
+
+    public void MarkAsPaused(Guid taskId)
+    {
+        // Not needed for tests
+    }
+
+    public bool CanStartNewDownload() => _active < MaxConcurrentDownloads;
+    public void ClearCompleted()
+    {
+        // Not needed for tests
+    }
+
+    public int PauseAll()
+    {
+        _active = 0;
+        return 0;
+    }
+
+    public IDownloadTask? GetTask(Guid taskId) => _queued.FirstOrDefault(t => t.Id == taskId);
+
+    public void Seed(params IDownloadTask[] tasks)
+    {
+        _queued.Clear();
+        _queued.AddRange(tasks);
+        SortQueue();
+    }
+
+    public void SetCounts(int active, int queued)
+    {
+        _active = active;
+        if (queued > _queued.Count)
+        {
+            var missing = queued - _queued.Count;
+            for (var i = 0; i < missing; i++)
+            {
+                _queued.Add(FakeDownloadTask.Create($"auto-{i}", CoreModels.DownloadPriority.Normal));
+            }
+        }
+        else if (queued < _queued.Count)
+        {
+            _queued.RemoveRange(queued, _queued.Count - queued);
+        }
+        SortQueue();
+    }
+
+    private void SortQueue()
+    {
+        _queued.Sort((a, b) => b.Priority.CompareTo(a.Priority));
+    }
+}
+
+public sealed class FakeStatisticsService : IStatisticsService
+{
+    public CoreModels.DownloadStatistics Statistics { get; } = new();
+
+    public Task<CoreModels.DownloadStatistics> GetStatisticsAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Statistics);
+    }
+
+    public Task RecordCompletedDownloadAsync(CoreModels.DownloadHistoryEntry entry, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task RecordFailedDownloadAsync(CoreModels.DownloadHistoryEntry entry, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task ResetSessionStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<IDictionary<string, object>> ExportStatisticsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult<IDictionary<string, object>>(new Dictionary<string, object>());
+}
+
+public sealed class FakeDownloadEngine : IDownloadEngine
+{
+    public Task<IDownloadTask> AddDownloadAsync(Uri url, CoreModels.DownloadOptions options, CancellationToken cancellationToken = default)
+        => Task.FromResult<IDownloadTask>(FakeDownloadTask.Create("added", CoreModels.DownloadPriority.Normal));
+
+    public Task CancelDownloadAsync(Guid taskId, bool removePartialFiles = false, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public bool ChangePriority(Guid taskId, CoreModels.DownloadPriority newPriority) => true;
+
+    public void ClearCompleted()
+    {
+    }
+
+    public IDownloadTask? GetDownload(Guid taskId) => null;
+
+    public IEnumerable<IDownloadTask> GetDownloads(CoreModels.DownloadStateFilter filter) => Array.Empty<IDownloadTask>();
+
+    public (int Active, int Queued) GetQueueStatistics() => (0, 0);
+
+    public Task PauseDownloadAsync(Guid taskId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<int> PauseAllAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(0);
+
+    public Task ResumeDownloadAsync(Guid taskId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task StartDownloadAsync(Guid taskId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public bool MoveDown(Guid taskId) => true;
+    public bool MoveUp(Guid taskId) => true;
+    public bool MoveToTop(Guid taskId) => true;
+    public bool MoveToBottom(Guid taskId) => true;
+    public IAsyncEnumerable<CoreModels.DownloadProgress> StreamProgressAsync(Guid? taskId = null, CancellationToken cancellationToken = default)
+        => AsyncEnumerable.Empty<CoreModels.DownloadProgress>();
+}

--- a/test/TESTING_STATUS.md
+++ b/test/TESTING_STATUS.md
@@ -1,0 +1,119 @@
+# Testing Dashboard (Issues #73 and #74)
+
+This document tracks progress on testing coverage for the dashboard surface as part of issue #74.
+
+## Completed
+
+### Authentication and CORS Configuration (#73) ✅
+- [x] Authentication infrastructure added to Kurio.Web and Kurio.Server
+- [x] CORS configuration enhanced with multiple policies
+- [x] Deployment documentation created (reverse-proxy, Docker, systemd)
+- [x] API key authentication support implemented
+- [x] Cookie-based authentication for dashboard UI
+
+### Integration Tests ✅
+- [x] Existing QueueAndStatsTests covers SignalR hub HTTP snapshots
+- [x] Integration tests verify queue management and stats endpoints
+- [x] ServerTestFactory provides test infrastructure for dashboard testing
+
+## Remaining Work
+
+### Unit Tests for SignalR Hubs
+SignalR hub unit tests were started but require API refinement:
+
+**Challenges:**
+- DownloadHub.ReceiveSnapshotAsync expects `IReadOnlyList<DownloadSummary>`, not `List<DownloadInfo>`
+- IDownloadQueueManager interface doesn't expose `GetActiveCount()` and `GetQueuedCount()` methods
+- Core model differences between test mocks and actual implementations
+
+**Next Steps:**
+1. Review and align hub client interfaces (IDownloadsClient, IQueueClient, IStatsClient)
+2. Verify DTO types match between contracts and hub implementations
+3. Complete unit tests with proper mocking of dependencies
+
+### Component Tests for Kurio.Web (bUnit)
+**Not Started** - Requires:
+1. Create Kurio.Web.Tests project
+2. Add bUnit and related packages
+3. Write component tests for:
+   - Overview page (dashboard summary)
+   - Downloads list (with filtering/sorting)
+   - Queue view (with drag/drop priority)
+   - Add download form (validation)
+   - Stats view (charts and metrics)
+   - Connection state indicators
+
+**Sample Test Structure:**
+```csharp
+public class OverviewPageTests : TestContext
+{
+    [Fact]
+    public void OverviewPage_DisplaysStats_WhenConnected()
+    {
+        // Arrange
+        var mockApiClient = new Mock<KurioApiClient>();
+        Services.AddSingleton(mockApiClient.Object);
+        
+        // Act
+        var cut = RenderComponent<Overview>();
+        
+        // Assert
+        cut.Find("h1").TextContent.Should().Be("Dashboard Overview");
+    }
+}
+```
+
+### CI Configuration
+**Not Started** - Requires:
+1. Add test execution to GitHub Actions workflow
+2. Configure test result reporting
+3. Add code coverage collection
+4. Set quality gates for pull requests
+
+## Test Coverage Summary
+
+| Component | Unit Tests | Integration Tests | Component Tests |
+|-----------|------------|-------------------|-----------------|
+| DownloadHub | ⏸️ Pending | ✅ Existing | N/A |
+| QueueHub | ⏸️ Pending | ✅ Existing | N/A |
+| StatsHub | ⏸️ Pending | ✅ Existing | N/A |
+| Queue Controller | N/A | ✅ Existing | N/A |
+| Stats Controller | N/A | ✅ Existing | N/A |
+| Overview Page | N/A | N/A | ⏸️ Not Started |
+| Downloads Page | N/A | N/A | ⏸️ Not Started |
+| Queue Page | N/A | N/A | ⏸️ Not Started |
+
+## Running Existing Tests
+
+```bash
+# Run all tests
+dotnet test
+
+# Run server tests only
+dotnet test test/Kurio.Server.Tests/Kurio.Server.Tests.csproj
+
+# Run with coverage
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+## Test Infrastructure
+
+### ServerTestFactory
+The existing `ServerTestFactory` provides:
+- Mock IDownloadEngine
+- Mock IDownloadQueueManager
+- Mock IStatisticsService
+- WebApplicationFactory<Program> for integration testing
+
+### FakeDownloadTask
+Implements `IDownloadTask` for test scenarios with configurable:
+- State, Priority, Progress
+- URLs, FileNames, Options
+- Metadata and error tracking
+
+## References
+
+- [bUnit Documentation](https://bunit.dev/)
+- [xUnit Documentation](https://xunit.net/)
+- [Moq Documentation](https://github.com/moq/moq4)
+- [ASP.NET Core Integration Tests](https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests)


### PR DESCRIPTION
- **chore: bump version to 1.13.2**
  

- **docs: add web dashboard PRD**
  

- **chore: bump version to 1.14.0**
  

- **feat: add Kurio.Contracts for dashboard**
  

- **chore: bump version to 1.15.0**
  

- **feat: add dashboard queue and stats hubs**
  

- **chore: bump version to 1.15.1**
  

- **fix: harden server queue and stats**
  

- **chore: bump version to 1.16.0**
  

- **feat: add web dashboard host shell**
  

- **chore: bump version to 1.17.0**
  

- **feat: implement web dashboard ui**
  

- **feat(auth): add authentication infrastructure for dashboard**
  Add authentication plumbing to support optional API key-based
  authentication between Kurio.Web dashboard and Kurio.Server backend.
  This infrastructure is disabled by default to maintain compatibility
  with local development workflows.
  
  Changes:
  - Add authentication configuration options to Kurio.Server appsettings
    with 'Enabled' and 'Scheme' properties for flexible auth approaches
  - Extend KurioServerOptions in Kurio.Web with AuthenticationOptions
    including ApiKey support for server communication
  - Update Kurio.Web Program.cs with cookie-based authentication support
    for Blazor Server, conditionally enabled via configuration
  - Modify HubClientFactory to inject X-Api-Key header in SignalR
    connections when authentication is enabled
  - Configure KurioApiClient to add X-Api-Key header to HTTP requests
    when server authentication is enabled
  - Add bUnit package references to Directory.Packages.props for
    upcoming component test implementation
  
  The authentication is opt-in via 'Authentication:Enabled' setting in
  appsettings, defaulting to false for seamless local dev experience.
  When enabled, supports API key authentication for server-to-UI
  communication and cookie-based session management for web UI access.
  
  Relates-to: #73
  

- **feat(cors): enhance CORS configuration for production and dev scenarios**
  Improve CORS setup in Kurio.Server to support both local development
  workflows and production reverse-proxy deployments with configurable
  policies and stricter same-origin option.
  
  Changes:
  - Add configurable CORS policy selection via 'Kurio:Server:CorsPolicy'
    setting, defaulting to 'AllowWebClients' for flexibility
  - Implement 'AllowWebClients' policy with wildcard subdomain support
    for development scenarios with multiple frontend hosts
  - Add 'SameOriginOnly' policy for production reverse-proxy scenarios
    where UI and API are served from same domain
  - Add 'BaseUrl' configuration to server settings for same-origin
    policy reference and documentation
  - Update Development appsettings to include https://localhost:5001
    in allowed origins for Kurio.Web default configuration
  - Configure SetIsOriginAllowedToAllowWildcardSubdomains() to support
    patterns like 'http://*.example.com' for staging environments
  
  The enhanced CORS configuration maintains backward compatibility with
  existing development setups while providing production-ready options
  for secure cross-origin resource sharing with SignalR negotiation.
  
  Relates-to: #73
  

- **docs(deployment): add comprehensive reverse-proxy and deployment guides**
  Create detailed deployment documentation for Kurio dashboard covering
  reverse proxy configuration, authentication, Docker deployment, and
  production best practices.
  
  New documentation:
  - docs/deployment/reverse-proxy.md: Complete guide for YARP, Nginx,
    and Caddy reverse proxy configurations with production-ready examples
    for hosting dashboard and API under single domain
  - docs/deployment/dashboard-deployment.md: Comprehensive deployment
    guide covering same-origin and cross-origin deployment patterns,
    authentication setup, environment-specific configurations, systemd
    service definitions, Docker deployment, health monitoring, performance
    tuning, logging, and security checklist
  
  Key topics covered:
  - YARP configuration with ASP.NET Core gateway setup
  - Nginx configuration with WebSocket/SignalR support and long timeouts
  - Caddy configuration with automatic HTTPS via Let's Encrypt
  - Docker Compose multi-service deployment with nginx
  - Same-origin deployment (recommended) vs cross-origin deployment
  - API key authentication setup and security best practices
  - Environment-specific settings (dev, staging, production)
  - Systemd service configurations for Linux deployments
  - Health check endpoints and monitoring strategies
  - Performance tuning for SignalR and download engine
  - Troubleshooting common deployment issues
  - Complete security checklist for production deployments
  
  The documentation provides copy-paste ready configurations for all
  major reverse proxy solutions, making it easy to deploy Kurio dashboard
  in production with proper security and performance settings.
  
  Relates-to: #73
  

- **docs(testing): add comprehensive testing status for dashboard**
  Document current state of testing coverage for dashboard features
  as part of implementing issues #73 and #74. Outline completed work,
  remaining tasks, and provide guidance for future test development.
  
  Completed:
  - Authentication and CORS configuration with deployment docs
  - Integration tests for queue/stats via existing QueueAndStatsTests
  - ServerTestFactory infrastructure for dashboard API testing
  
  Remaining:
  - SignalR hub unit tests (started, need API alignment)
  - Kurio.Web component tests with bUnit (not started)
  - CI configuration for automated test execution
  
  The TESTING_STATUS.md provides:
  - Test coverage summary table showing current status
  - Detailed explanation of challenges with hub unit tests
  - Sample test structure for bUnit component testing
  - Instructions for running existing tests
  - References to test infrastructure (ServerTestFactory, FakeDownloadTask)
  - Links to relevant documentation
  
  This documentation establishes a clear roadmap for completing
  testing requirements outlined in issue #74 while tracking progress
  toward comprehensive dashboard test coverage.
  
  Relates-to: #74
  

- **chore: bump version to 1.18.0**
  Increment minor version from 1.17.0 to 1.18.0 for new features:
  - Authentication infrastructure for dashboard (API key + cookies)
  - Enhanced CORS configuration with multiple policies
  - Comprehensive deployment documentation (YARP, Nginx, Caddy)
  - Testing infrastructure and documentation for dashboard
  
  This minor version bump follows semantic versioning for new
  backward-compatible functionality added in issues #73 and #74.
  